### PR TITLE
Signature Aggregation Preparation (devnet 2)

### DIFF
--- a/lean_client/Cargo.lock
+++ b/lean_client/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
 name = "containers"
 version = "0.1.0"
 dependencies = [
+ "env-config",
  "hex",
  "leansig",
  "pretty_assertions",
@@ -1400,6 +1401,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "env-config"
+version = "0.1.0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1586,6 +1591,7 @@ name = "fork-choice"
 version = "0.1.0"
 dependencies = [
  "containers",
+ "env-config",
  "serde",
  "serde_json",
  "ssz",
@@ -2311,7 +2317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -3217,6 +3223,7 @@ dependencies = [
  "async-trait",
  "containers",
  "enr",
+ "env-config",
  "futures",
  "libp2p",
  "libp2p-identity 0.2.12",
@@ -3265,7 +3272,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4268,7 +4275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4919,7 +4926,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5340,6 +5347,7 @@ name = "validator"
 version = "0.1.0"
 dependencies = [
  "containers",
+ "env-config",
  "fork-choice",
  "leansig",
  "serde",

--- a/lean_client/Cargo.toml
+++ b/lean_client/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["chain", "containers", "fork_choice", "networking", "validator"]
+members = ["chain", "containers", "env-config", "fork_choice", "networking", "validator"]
 resolver = "2"
 
 [workspace.package]
@@ -14,7 +14,7 @@ containers = { path = "./containers" }
 fork_choice = { path = "./fork_choice" }
 networking = { path = "./networking" }
 validator = { path = "./validator" }
-libp2p = {version =  "0.56.0", default-features = false, features = [
+libp2p = { version = "0.56.0", default-features = false, features = [
     'dns',
     'gossipsub',
     'identify',
@@ -52,8 +52,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["xmss-signing"]
+default = ["devnet2", "xmss-signing"]
 xmss-signing = ["validator/xmss-signing"]
+devnet1 = ["containers/devnet1", "fork-choice/devnet1", "networking/devnet1", "validator/devnet1"]
+devnet2 = ["containers/devnet2", "fork-choice/devnet2", "networking/devnet2", "validator/devnet2"]
 
 [dependencies]
 chain = { path = "./chain" }

--- a/lean_client/ENVIRONMENT_SELECTION.md
+++ b/lean_client/ENVIRONMENT_SELECTION.md
@@ -1,0 +1,26 @@
+### To select which devnet you want to compile
+
+#### Option A
+- Change the default features in root `Cargo.toml`:
+```toml
+[features]
+default = ["devnet1", "<...other features>"]  # Change to "devnet2" if needed
+devnet1 = [...]
+devnet2 = [...]
+```
+
+#### Option B
+- Use the `--no-default-features` flag and specify the desired devnet feature when building or running the project:
+```bash
+cargo build --no-default-features --features devnet1  # Change to devnet2
+```
+
+
+### Running tests for a specific devnet
+
+From root directory, use the following command:
+```bash
+cargo test -p <crate_name> --no-default-features --features devnet1  # Change to devnet2
+```
+
+Use `<crate_name>` to specify the crate you want to test.

--- a/lean_client/containers/Cargo.toml
+++ b/lean_client/containers/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [features]
 xmss-verify = ["leansig"]
+default = ["devnet1"]
+devnet1 = []
+devnet2 = []
 
 [lib]
 name = "containers"

--- a/lean_client/containers/Cargo.toml
+++ b/lean_client/containers/Cargo.toml
@@ -5,15 +5,16 @@ edition = "2021"
 
 [features]
 xmss-verify = ["leansig"]
-default = ["devnet1"]
-devnet1 = []
-devnet2 = []
+default = []
+devnet1 = ["env-config/devnet1"]
+devnet2 = ["env-config/devnet2"]
 
 [lib]
 name = "containers"
 path = "src/lib.rs"
 
 [dependencies]
+env-config = { path = "../env-config", default-features = false }
 ssz = { git = "https://github.com/grandinetech/grandine", package = "ssz", branch = "develop", submodules = true }
 ssz_derive = { git = "https://github.com/grandinetech/grandine", package = "ssz_derive", branch = "develop", submodules = false }
 typenum = "1"

--- a/lean_client/containers/src/attestation.rs
+++ b/lean_client/containers/src/attestation.rs
@@ -111,8 +111,12 @@ pub struct Attestation {
 /// Validator attestation bundled with its signature.
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
 pub struct SignedAttestation {
+    #[cfg(feature = "devnet2")]
+    pub validator_id: u64,
+    #[cfg(feature = "devnet2")]
+    pub message: AttestationData,
+    #[cfg(feature = "devnet1")]
     pub message: Attestation,
-    /// Signature aggregation produced by the leanVM (SNARKs in the future).
     pub signature: Signature,
 }
 

--- a/lean_client/containers/src/attestation.rs
+++ b/lean_client/containers/src/attestation.rs
@@ -19,9 +19,9 @@ use typenum::U4096;
 /// Limit is VALIDATOR_REGISTRY_LIMIT (4096).
 pub type Attestations = ssz::PersistentList<Attestation, U4096>;
 
-/// List of signatures corresponding to attestations in a block.
-/// Limit is VALIDATOR_REGISTRY_LIMIT (4096).
-pub type BlockSignatures = ssz::PersistentList<Signature, U4096>;
+pub type AggregatedAttestations = ssz::PersistentList<AggregatedAttestation, U4096>;
+
+pub type AttestationSignatures = ssz::PersistentList<SignedAttestation, U4096>;
 
 /// Bitlist representing validator participation in an attestation.
 /// Limit is VALIDATOR_REGISTRY_LIMIT (4096).
@@ -57,15 +57,19 @@ pub struct Attestation {
 /// Validator attestation bundled with its signature.
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
 pub struct SignedAttestation {
-    /// The attestation message signed by the validator.
+    #[cfg(feature = "devnet2")]
+    pub validator_id: u64,
+    #[cfg(feature = "devnet2")]
+    pub message: AttestationData,
+    #[cfg(feature = "devnet1")]
     pub message: Attestation,
-    /// Signature aggregation produced by the leanVM (SNARKs in the future).
+    /// signature over attestaion message only as it would be aggregated later in attestation
     pub signature: Signature,
 }
 
 /// Aggregated attestation consisting of participation bits and message.
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
-pub struct AggregatedAttestations {
+pub struct AggregatedAttestation {
     /// Bitfield indicating which validators participated in the aggregation.
     pub aggregation_bits: AggregationBits,
     /// Combined attestation data similar to the beacon chain format.
@@ -77,9 +81,9 @@ pub struct AggregatedAttestations {
 
 /// Aggregated attestation bundled with aggregated signatures.
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
-pub struct SignedAggregatedAttestations {
+pub struct SignedAggregatedAttestation {
     /// Aggregated attestation data.
-    pub message: AggregatedAttestations,
+    pub message: AggregatedAttestation,
     /// Aggregated attestation plus its combined signature.
     ///
     /// Stores a naive list of validator signatures that mirrors the attestation

--- a/lean_client/containers/src/block.rs
+++ b/lean_client/containers/src/block.rs
@@ -1,9 +1,12 @@
-use crate::{Attestation, Attestations, BlockSignatures, Bytes32, Signature, Slot, State, ValidatorIndex};
+use crate::{Attestation, Attestations, Bytes32, Signature, Slot, State, ValidatorIndex};
 use serde::{Deserialize, Serialize};
 use ssz_derive::Ssz;
 
 #[cfg(feature = "xmss-verify")]
 use leansig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::target_sum::SIGTargetSumLifetime20W2NoOff;
+use ssz::PersistentList;
+use typenum::U4096;
+use crate::attestation::AttestationSignatures;
 
 /// The body of a block, containing payload data.
 ///
@@ -11,6 +14,9 @@ use leansig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to
 /// separately in BlockSignatures to match the spec architecture.
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
 pub struct BlockBody {
+    #[cfg(feature = "devnet2")]
+    pub attestations: VariableList<AggregatedAttestations, U4096>,
+    #[cfg(feature = "devnet1")]
     #[serde(with = "crate::serde_helpers")]
     pub attestations: Attestations,
 }
@@ -45,6 +51,12 @@ pub struct BlockWithAttestation {
     pub proposer_attestation: Attestation,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct BlockSignatures {
+    pub attestation_signatures: AttestationSignatures,
+    pub proposer_signature: Signature,
+}
+
 /// Envelope carrying a block, an attestation from proposer, and aggregated signatures.
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,7 +66,10 @@ pub struct SignedBlockWithAttestation {
     /// Aggregated signature payload for the block.
     ///
     /// Signatures remain in attestation order followed by the proposer signature.
+    #[cfg(feature = "devnet1")]
     #[serde(with = "crate::serde_helpers::block_signatures")]
+    pub signature: PersistentList<Signature, U4096>,
+    #[cfg(feature = "devnet2")]
     pub signature: BlockSignatures,
 }
 

--- a/lean_client/containers/src/block.rs
+++ b/lean_client/containers/src/block.rs
@@ -170,25 +170,10 @@ impl SignedBlockWithAttestation {
         // The ordering must be preserved:
         // 1. Block body attestations,
         // 2. The proposer attestation.
-        assert!(
-            signatures_vec.len() == all_attestations.len(),
-            "Number of signatures does not match number of attestations"
-        );
+        assert_eq!(signatures_vec.len(), all_attestations.len(), "Number of signatures does not match number of attestations");
 
         let validators = &parent_state.validators;
-
-        // Count validators (PersistentList doesn't expose len directly)
-        let mut num_validators: u64 = 0;
-        let mut k: u64 = 0;
-        loop {
-            match validators.get(k) {
-                Ok(_) => {
-                    num_validators += 1;
-                    k += 1;
-                }
-                Err(_) => break,
-            }
-        }
+        let num_validators = validators.len_u64();
 
         // Verify each attestation signature
         for (attestation, signature) in all_attestations.iter().zip(signatures_vec.iter()) {

--- a/lean_client/containers/src/block.rs
+++ b/lean_client/containers/src/block.rs
@@ -4,9 +4,10 @@ use ssz_derive::Ssz;
 
 #[cfg(feature = "xmss-verify")]
 use leansig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::target_sum::SIGTargetSumLifetime20W2NoOff;
-use ssz::PersistentList;
+use ssz::{PersistentList, SszHash};
 use typenum::U4096;
-use crate::attestation::AttestationSignatures;
+use crate::attestation::{AggregatedAttestations, AttestationSignatures};
+use crate::validator::BlsPublicKey;
 
 /// The body of a block, containing payload data.
 ///
@@ -15,7 +16,7 @@ use crate::attestation::AttestationSignatures;
 #[derive(Clone, Debug, PartialEq, Eq, Ssz, Default, Serialize, Deserialize)]
 pub struct BlockBody {
     #[cfg(feature = "devnet2")]
-    pub attestations: VariableList<AggregatedAttestations, U4096>,
+    pub attestations: AggregatedAttestations,
     #[cfg(feature = "devnet1")]
     #[serde(with = "crate::serde_helpers")]
     pub attestations: Attestations,
@@ -51,7 +52,7 @@ pub struct BlockWithAttestation {
     pub proposer_attestation: Attestation,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Ssz, Deserialize, Default)]
 pub struct BlockSignatures {
     pub attestation_signatures: AttestationSignatures,
     pub proposer_signature: Signature,
@@ -127,6 +128,7 @@ impl SignedBlockWithAttestation {
     ///
     /// - Spec: <https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/containers/block/block.py#L35>
     /// - XMSS Library: <https://github.com/leanEthereum/leanSig>
+    #[cfg(feature = "devnet1")]
     pub fn verify_signatures(&self, parent_state: State) -> bool {
         // Unpack the signed block components
         let block = &self.message.block;
@@ -138,7 +140,7 @@ impl SignedBlockWithAttestation {
         // 1. Block body attestations (from other validators)
         // 2. Proposer attestation (from the block producer)
         let mut all_attestations: Vec<Attestation> = Vec::new();
-        
+
         // Collect block body attestations
         let mut i: u64 = 0;
         loop {
@@ -148,7 +150,7 @@ impl SignedBlockWithAttestation {
             }
             i += 1;
         }
-        
+
         // Append proposer attestation
         all_attestations.push(self.message.proposer_attestation.clone());
 
@@ -170,7 +172,11 @@ impl SignedBlockWithAttestation {
         // The ordering must be preserved:
         // 1. Block body attestations,
         // 2. The proposer attestation.
-        assert_eq!(signatures_vec.len(), all_attestations.len(), "Number of signatures does not match number of attestations");
+        assert_eq!(
+            signatures_vec.len(),
+            all_attestations.len(),
+            "Number of signatures does not match number of attestations"
+        );
 
         let validators = &parent_state.validators;
         let num_validators = validators.len_u64();
@@ -193,60 +199,149 @@ impl SignedBlockWithAttestation {
             // - The validator possesses the secret key for their public key
             // - The attestation has not been tampered with
             // - The signature was created at the correct epoch (slot)
-            
-            #[cfg(feature = "xmss-verify")]
-            {
-                use leansig::signature::SignatureScheme;
-                use leansig::serialization::Serializable;
-                
-                // Compute the message hash from the attestation
-                let message_bytes: [u8; 32] = hash_tree_root(attestation).0.into();
-                let epoch = attestation.data.slot.0 as u32;
-                
-                // Get public key bytes - use as_bytes() method
-                let pubkey_bytes = validator.pubkey.0.as_bytes();
-                
-                // Deserialize the public key using Serializable trait
-                type PubKey = <SIGTargetSumLifetime20W2NoOff as SignatureScheme>::PublicKey;
-                let pubkey = match PubKey::from_bytes(pubkey_bytes) {
-                    Ok(pk) => pk,
-                    Err(e) => {
-                        eprintln!("Failed to deserialize public key at slot {:?}: {:?}", attestation.data.slot, e);
-                        return false;
-                    }
-                };
-                
-                // Get signature bytes - use as_bytes() method
-                let sig_bytes = signature.as_bytes();
-                
-                // Deserialize the signature using Serializable trait
-                type Sig = <SIGTargetSumLifetime20W2NoOff as SignatureScheme>::Signature;
-                let sig = match Sig::from_bytes(sig_bytes) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        eprintln!("Failed to deserialize signature at slot {:?}: {:?}", attestation.data.slot, e);
-                        return false;
-                    }
-                };
-                
-                // Verify the signature
-                if !SIGTargetSumLifetime20W2NoOff::verify(&pubkey, epoch, &message_bytes, &sig) {
-                    eprintln!("XMSS signature verification failed at slot {:?}", attestation.data.slot);
-                    return false;
-                }
-            }
-            
-            #[cfg(not(feature = "xmss-verify"))]
-            {
-                // Placeholder: XMSS verification disabled
-                // To enable, compile with --features xmss-verify
-                let _pubkey = &validator.pubkey;
-                let _slot = attestation.data.slot;
-                let _message = hash_tree_root(attestation);
-                let _sig = signature;
-            }
+
+            let message_bytes: [u8; 32] = hash_tree_root(attestation).0.into();
+
+            assert!(
+                verify_xmss_signature(
+                    validator.pubkey.0.as_bytes(),
+                    attestation.data.slot,
+                    &message_bytes,
+                    &signature,
+                ),
+                "Attestation signature verification failed"
+            );
         }
 
         true
     }
+
+    #[cfg(feature = "devnet2")]
+    pub fn verify_signatures(&self, parent_state: State) -> bool {
+        // Unpack the signed block components
+        let block = &self.message.block;
+        let signatures = &self.signature;
+        let aggregated_attestations = block.body.attestations.clone();
+        let attestation_signatures = signatures.attestation_signatures.clone();
+
+        // Verify signature count matches aggregated attestation count
+        assert_eq!(
+            aggregated_attestations.len_u64(),
+            attestation_signatures.len_u64(),
+            "Number of signatures does not match number of attestations"
+        );
+
+        let validators = &parent_state.validators;
+        let num_validators = validators.len_u64();
+
+        // Verify each attestation signature
+        for (aggregated_attestation, aggregated_signature) in (&aggregated_attestations)
+            .into_iter()
+            .zip((&attestation_signatures).into_iter())
+        {
+            let validator_ids = aggregated_attestation
+                .aggregation_bits
+                .to_validator_indices();
+
+            assert_eq!(
+                aggregated_signature.len_u64(),
+                validator_ids.len() as u64,
+                "Aggregated attestation signature count mismatch"
+            );
+
+            let attestation_root = aggregated_attestation.data.hash_tree_root();
+
+            // Loop through zipped validator IDs and their corresponding signatures
+            // Verify each individual signature within the aggregated attestation
+            for (validator_id, signature) in
+                validator_ids.iter().zip(aggregated_signature.into_iter())
+            {
+                // Ensure validator exists in the active set
+                assert!(
+                    *validator_id < num_validators,
+                    "Validator index out of range"
+                );
+
+                let validator = validators.get(*validator_id).expect("validator must exist");
+
+                // Get the actual payload root for the attestation data
+                let attestation_root: [u8; 32] =
+                    hash_tree_root(&aggregated_attestation.data).0.into();
+
+                // Verify the XMSS signature
+                assert!(
+                    verify_xmss_signature(
+                        validator.pubkey.0.as_bytes(),
+                        aggregated_attestation.data.slot,
+                        &attestation_root,
+                        signature,
+                    ),
+                    "Attestation signature verification failed"
+                );
+            }
+
+            // Verify the proposer attestation signature
+            let proposer_attestation = self.message.proposer_attestation.clone();
+            let proposer_signature = signatures.proposer_signature;
+
+            assert!(
+                proposer_attestation.validator_id.0 < num_validators,
+                "Proposer index out of range"
+            );
+
+            let proposer = validators
+                .get(proposer_attestation.validator_id.0)
+                .expect("proposer must exist");
+
+            let proposer_root: [u8; 32] = hash_tree_root(&proposer_attestation).0.into();
+            assert!(
+                verify_xmss_signature(
+                    proposer.pubkey.0.as_bytes(),
+                    proposer_attestation.data.slot,
+                    &proposer_root,
+                    &proposer_signature,
+                ),
+                "Proposer attestation signature verification failed"
+            );
+        }
+
+        true
+    }
+}
+
+#[cfg(feature = "xmss-verify")]
+pub fn verify_xmss_signature(
+    pubkey_bytes: &[u8],
+    slot: Slot,
+    message_bytes: &[u8; 32],
+    signature: &Signature,
+) -> bool {
+    use leansig::serialization::Serializable;
+    use leansig::signature::SignatureScheme;
+
+    let epoch = slot.0 as u32;
+
+    type PubKey = <SIGTargetSumLifetime20W2NoOff as SignatureScheme>::PublicKey;
+    let pubkey = match PubKey::from_bytes(pubkey_bytes) {
+        Ok(pk) => pk,
+        Err(_) => return false,
+    };
+
+    type Sig = <SIGTargetSumLifetime20W2NoOff as SignatureScheme>::Signature;
+    let sig = match Sig::from_bytes(signature.as_bytes()) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    SIGTargetSumLifetime20W2NoOff::verify(&pubkey, epoch, message_bytes, &sig)
+}
+
+#[cfg(not(feature = "xmss-verify"))]
+pub fn verify_xmss_signature(
+    _pubkey_bytes: &[u8],
+    _slot: Slot,
+    _message_bytes: &[u8; 32],
+    _signature: &Signature,
+) -> bool {
+    true
 }

--- a/lean_client/containers/src/lib.rs
+++ b/lean_client/containers/src/lib.rs
@@ -10,8 +10,8 @@ pub mod types;
 pub mod validator;
 
 pub use attestation::{
-    AggregatedAttestations, AggregatedSignatures, AggregationBits, Attestation, AttestationData,
-    Attestations, BlockSignatures, Signature, SignedAggregatedAttestations, SignedAttestation,
+    AggregatedAttestation, AggregatedSignatures, AggregationBits, Attestation, AttestationData,
+    Attestations, Signature, SignedAggregatedAttestation, SignedAttestation,
 };
 pub use block::{
     Block, BlockBody, BlockHeader, BlockWithAttestation, SignedBlock, SignedBlockWithAttestation,

--- a/lean_client/containers/src/serde_helpers.rs
+++ b/lean_client/containers/src/serde_helpers.rs
@@ -187,6 +187,7 @@ pub mod signature {
 /// where each signature can be either hex string or structured XMSS format
 pub mod block_signatures {
     use super::*;
+    use crate::block::BlockSignatures;
     use crate::Signature;
     use serde_json::Value;
     use ssz::PersistentList;
@@ -309,11 +310,11 @@ pub mod block_signatures {
     }
 
     #[cfg(feature = "devnet2")]
-    pub fn serialize<S>(value: &BlockSignatures, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(_value: &BlockSignatures, _serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        Err(serde::de::Error::custom(
+        Err(serde::ser::Error::custom(
             "BlockSignatures serialization not implemented for devnet2",
         ))
     }

--- a/lean_client/containers/src/serde_helpers.rs
+++ b/lean_client/containers/src/serde_helpers.rs
@@ -34,26 +34,26 @@ where
 pub mod bitlist {
     use super::*;
     use ssz::BitList;
-    use typenum::Unsigned;
     use ssz::SszRead;
-    
+    use typenum::Unsigned;
+
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum BitListData {
         HexString(String),
         BoolArray(Vec<bool>),
     }
-    
+
     pub fn deserialize<'de, D, N>(deserializer: D) -> Result<BitList<N>, D::Error>
     where
         D: Deserializer<'de>,
         N: Unsigned,
     {
         use serde::de::Error;
-        
+
         // First unwrap the {"data": ...} wrapper
         let wrapper = DataWrapper::<BitListData>::deserialize(deserializer)?;
-        
+
         match wrapper.data {
             BitListData::HexString(hex_str) => {
                 // Handle hex string format (e.g., "0x01ff")
@@ -62,10 +62,10 @@ pub mod bitlist {
                     // Empty hex string means empty bitlist
                     return Ok(BitList::default());
                 }
-                
+
                 let bytes = hex::decode(hex_str)
                     .map_err(|e| D::Error::custom(format!("Invalid hex string: {}", e)))?;
-                
+
                 // Decode SSZ bitlist (with delimiter bit)
                 BitList::from_ssz_unchecked(&(), &bytes)
                     .map_err(|e| D::Error::custom(format!("Invalid SSZ bitlist: {:?}", e)))
@@ -80,19 +80,20 @@ pub mod bitlist {
             }
         }
     }
-    
+
     pub fn serialize<S, N>(value: &BitList<N>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
         N: Unsigned,
     {
         use ssz::SszWrite;
-        
+
         // Serialize as hex string in {"data": "0x..."} format
         let mut bytes = Vec::new();
-        value.write_variable(&mut bytes)
+        value
+            .write_variable(&mut bytes)
             .map_err(|e| serde::ser::Error::custom(format!("Failed to write SSZ: {:?}", e)))?;
-        
+
         let hex_str = format!("0x{}", hex::encode(&bytes));
         let wrapper = DataWrapper { data: hex_str };
         wrapper.serialize(serializer)
@@ -103,9 +104,9 @@ pub mod bitlist {
 /// Signatures in test vectors are structured with {path, rho, hashes} instead of hex bytes
 pub mod signature {
     use super::*;
-    use serde_json::Value;
     use crate::Signature;
-    
+    use serde_json::Value;
+
     /// Structured XMSS signature format from test vectors
     #[derive(Deserialize)]
     struct XmssSignature {
@@ -113,65 +114,65 @@ pub mod signature {
         rho: DataWrapper<Vec<u32>>,
         hashes: DataWrapper<Vec<DataWrapper<Vec<u32>>>>,
     }
-    
+
     #[derive(Deserialize)]
     struct XmssPath {
         siblings: DataWrapper<Vec<DataWrapper<Vec<u32>>>>,
     }
-    
+
     pub fn deserialize_single<'de, D>(deserializer: D) -> Result<Signature, D::Error>
     where
         D: Deserializer<'de>,
     {
         use serde::de::Error;
-        
+
         // First, try to parse as a JSON value to inspect the structure
         let value = Value::deserialize(deserializer)?;
-        
+
         // Check if it's a hex string (normal format)
         if let Value::String(hex_str) = &value {
             let hex_str = hex_str.trim_start_matches("0x");
             let bytes = hex::decode(hex_str)
                 .map_err(|e| D::Error::custom(format!("Invalid hex string: {}", e)))?;
-            
+
             return Signature::try_from(bytes.as_slice())
                 .map_err(|_| D::Error::custom("Invalid signature length"));
         }
-        
+
         // Otherwise, parse as structured XMSS signature
         let xmss_sig: XmssSignature = serde_json::from_value(value)
             .map_err(|e| D::Error::custom(format!("Failed to parse XMSS signature: {}", e)))?;
-        
+
         // Serialize the XMSS signature to bytes
         // Format: siblings (variable length) + rho (28 bytes) + hashes (variable length)
         let mut bytes = Vec::new();
-        
+
         // Write siblings
         for sibling in &xmss_sig.path.siblings.data {
             for val in &sibling.data {
                 bytes.extend_from_slice(&val.to_le_bytes());
             }
         }
-        
+
         // Write rho (7 u32s = 28 bytes)
         for val in &xmss_sig.rho.data {
             bytes.extend_from_slice(&val.to_le_bytes());
         }
-        
+
         // Write hashes
         for hash in &xmss_sig.hashes.data {
             for val in &hash.data {
                 bytes.extend_from_slice(&val.to_le_bytes());
             }
         }
-        
+
         // Pad or truncate to 3112 bytes
         bytes.resize(3112, 0);
-        
+
         Signature::try_from(bytes.as_slice())
             .map_err(|_| D::Error::custom("Failed to create signature"))
     }
-    
+
     pub fn serialize<S>(value: &Signature, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -186,10 +187,11 @@ pub mod signature {
 /// where each signature can be either hex string or structured XMSS format
 pub mod block_signatures {
     use super::*;
-    use crate::{Signature, BlockSignatures};
-    use ssz::PersistentList;
+    use crate::Signature;
     use serde_json::Value;
-    
+    use ssz::PersistentList;
+    use typenum::U4096;
+
     /// Structured XMSS signature format from test vectors
     #[derive(Deserialize, Clone)]
     struct XmssSignature {
@@ -197,79 +199,95 @@ pub mod block_signatures {
         rho: DataWrapper<Vec<u32>>,
         hashes: DataWrapper<Vec<DataWrapper<Vec<u32>>>>,
     }
-    
+
     #[derive(Deserialize, Clone)]
     struct XmssPath {
         siblings: DataWrapper<Vec<DataWrapper<Vec<u32>>>>,
     }
-    
+
     fn parse_single_signature(value: &Value) -> Result<Signature, String> {
         // Check if it's a hex string (normal format)
         if let Value::String(hex_str) = value {
             let hex_str = hex_str.trim_start_matches("0x");
-            let bytes = hex::decode(hex_str)
-                .map_err(|e| format!("Invalid hex string: {}", e))?;
-            
+            let bytes = hex::decode(hex_str).map_err(|e| format!("Invalid hex string: {}", e))?;
+
             return Signature::try_from(bytes.as_slice())
                 .map_err(|_| "Invalid signature length".to_string());
         }
-        
+
         // Otherwise, parse as structured XMSS signature
         let xmss_sig: XmssSignature = serde_json::from_value(value.clone())
             .map_err(|e| format!("Failed to parse XMSS signature: {}", e))?;
-        
+
         // Serialize the XMSS signature to bytes
         // Format: siblings (variable length) + rho (28 bytes) + hashes (variable length)
         let mut bytes = Vec::new();
-        
+
         // Write siblings
         for sibling in &xmss_sig.path.siblings.data {
             for val in &sibling.data {
                 bytes.extend_from_slice(&val.to_le_bytes());
             }
         }
-        
+
         // Write rho (7 u32s = 28 bytes)
         for val in &xmss_sig.rho.data {
             bytes.extend_from_slice(&val.to_le_bytes());
         }
-        
+
         // Write hashes
         for hash in &xmss_sig.hashes.data {
             for val in &hash.data {
                 bytes.extend_from_slice(&val.to_le_bytes());
             }
         }
-        
+
         // Pad or truncate to 3112 bytes
         bytes.resize(3112, 0);
-        
-        Signature::try_from(bytes.as_slice())
-            .map_err(|_| "Failed to create signature".to_string())
+
+        Signature::try_from(bytes.as_slice()).map_err(|_| "Failed to create signature".to_string())
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<BlockSignatures, D::Error>
+    #[cfg(feature = "devnet1")]
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<PersistentList<Signature, U4096>, D::Error>
     where
         D: Deserializer<'de>,
     {
         use serde::de::Error;
-        
+
         // Parse the {"data": [...]} wrapper
         let wrapper: DataWrapper<Vec<Value>> = DataWrapper::deserialize(deserializer)?;
-        
+
         let mut signatures = PersistentList::default();
-        
+
         for (idx, sig_value) in wrapper.data.into_iter().enumerate() {
             let sig = parse_single_signature(&sig_value)
                 .map_err(|e| D::Error::custom(format!("Signature {}: {}", idx, e)))?;
-            signatures.push(sig)
+            signatures
+                .push(sig)
                 .map_err(|e| D::Error::custom(format!("Signature {} push failed: {:?}", idx, e)))?;
         }
-        
+
         Ok(signatures)
     }
-    
-    pub fn serialize<S>(value: &BlockSignatures, serializer: S) -> Result<S::Ok, S::Error>
+
+    #[cfg(feature = "devnet2")]
+    pub fn deserialize<'de, D>(_: D) -> Result<BlockSignatures, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Err(serde::de::Error::custom(
+            "BlockSignatures deserialization not implemented for devnet2",
+        ))
+    }
+
+    #[cfg(feature = "devnet1")]
+    pub fn serialize<S>(
+        value: &PersistentList<Signature, U4096>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -285,8 +303,18 @@ pub mod block_signatures {
                 Err(_) => break,
             }
         }
-        
+
         let wrapper = DataWrapper { data: sigs };
         wrapper.serialize(serializer)
+    }
+
+    #[cfg(feature = "devnet2")]
+    pub fn serialize<S>(value: &BlockSignatures, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(serde::de::Error::custom(
+            "BlockSignatures serialization not implemented for devnet2",
+        ))
     }
 }

--- a/lean_client/containers/src/state.rs
+++ b/lean_client/containers/src/state.rs
@@ -1,13 +1,13 @@
 use crate::validator::Validator;
+use crate::{block::{hash_tree_root, Block, BlockBody, BlockHeader, SignedBlockWithAttestation}, Attestation, Attestations, Bytes32, Checkpoint, Config, Signature, Slot, Uint64, ValidatorIndex};
 use crate::{
-    block::{hash_tree_root, Block, BlockBody, BlockHeader, SignedBlockWithAttestation},
-    Attestation, Attestations, BlockSignatures, Bytes32, Checkpoint, Config, Slot, Uint64, ValidatorIndex,
+    HistoricalBlockHashes, JustificationRoots, JustificationsValidators, JustifiedSlots, Validators,
 };
-use crate::{HistoricalBlockHashes, JustificationRoots, JustificationsValidators, JustifiedSlots, Validators};
 use serde::{Deserialize, Serialize};
-use ssz::{PersistentList as List};
+use ssz::{PersistentList as List, PersistentList};
 use ssz_derive::Ssz;
 use std::collections::BTreeMap;
+use typenum::U4096;
 
 pub const VALIDATOR_REGISTRY_LIMIT: usize = 1 << 12; // 4096
 pub const JUSTIFICATION_ROOTS_LIMIT: usize = 1 << 18; // 262144
@@ -47,7 +47,10 @@ pub struct State {
 }
 
 impl State {
-        pub fn generate_genesis_with_validators(genesis_time: Uint64, validators: Vec<Validator>) -> Self {
+    pub fn generate_genesis_with_validators(
+        genesis_time: Uint64,
+        validators: Vec<Validator>,
+    ) -> Self {
         let body_for_root = BlockBody {
             attestations: Default::default(),
         };
@@ -63,7 +66,6 @@ impl State {
         for v in validators {
             validator_list.push(v).expect("Failed to add validator");
         }
-
 
         Self {
             config: Config {
@@ -206,7 +208,11 @@ impl State {
 
         for (i, r) in roots.iter().enumerate() {
             let v = map.get(r).expect("root present");
-            assert_eq!(v.len(), num_validators, "vote vector must match validator count");
+            assert_eq!(
+                v.len(),
+                num_validators,
+                "vote vector must match validator count"
+            );
             let base = i * num_validators;
             for (j, &bit) in v.iter().enumerate() {
                 if bit {
@@ -230,7 +236,11 @@ impl State {
     }
 
     // updated for fork choice tests
-    pub fn state_transition(&self, signed_block: SignedBlockWithAttestation, valid_signatures: bool) -> Result<Self, String> {
+    pub fn state_transition(
+        &self,
+        signed_block: SignedBlockWithAttestation,
+        valid_signatures: bool,
+    ) -> Result<Self, String> {
         self.state_transition_with_validation(signed_block, valid_signatures, true)
     }
 
@@ -314,7 +324,7 @@ impl State {
         }
 
         // Create a mutable clone for hash computation
-        let latest_header_for_hash  = self.latest_block_header.clone();
+        let latest_header_for_hash = self.latest_block_header.clone();
         let parent_root = hash_tree_root(&latest_header_for_hash);
         if block.parent_root != parent_root {
             return Err(String::from("Block parent root mismatch"));
@@ -554,6 +564,7 @@ impl State {
     /// # Returns
     ///
     /// Tuple of (Block, post-State, collected attestations, signatures)
+    #[cfg(feature = "devnet1")]
     pub fn build_block(
         &self,
         slot: Slot,
@@ -562,10 +573,10 @@ impl State {
         initial_attestations: Option<Vec<Attestation>>,
         available_signed_attestations: Option<&[SignedBlockWithAttestation]>,
         known_block_roots: Option<&std::collections::HashSet<Bytes32>>,
-    ) -> Result<(Block, Self, Vec<Attestation>, BlockSignatures), String> {
+    ) -> Result<(Block, Self, Vec<Attestation>, PersistentList<Signature, U4096>), String> {
         // Initialize empty attestation set for iterative collection
         let mut attestations = initial_attestations.unwrap_or_default();
-        let mut signatures = BlockSignatures::default();
+        let mut signatures = PersistentList::default();
 
         // Advance state to target slot
         // Note: parent_root comes from fork choice and is already validated.
@@ -581,7 +592,9 @@ impl State {
             // Create candidate block with current attestation set
             let mut attestations_list = Attestations::default();
             for att in &attestations {
-                attestations_list.push(att.clone()).map_err(|e| format!("Failed to push attestation: {:?}", e))?;
+                attestations_list
+                    .push(att.clone())
+                    .map_err(|e| format!("Failed to push attestation: {:?}", e))?;
             }
 
             let candidate_block = Block {
@@ -666,9 +679,24 @@ impl State {
             // Add new attestations and continue iteration
             attestations.extend(new_attestations);
             for sig in new_signatures {
-                signatures.push(sig).map_err(|e| format!("Failed to push signature: {:?}", e))?;
+                signatures
+                    .push(sig)
+                    .map_err(|e| format!("Failed to push signature: {:?}", e))?;
             }
         }
+    }
+
+    #[cfg(feature = "devnet2")]
+    pub fn build_block(
+        &self,
+        _slot: Slot,
+        _proposer_index: ValidatorIndex,
+        _parent_root: Bytes32,
+        _initial_attestations: Option<Vec<Attestation>>,
+        _available_signed_attestations: Option<&[SignedBlockWithAttestation]>,
+        _known_block_roots: Option<&std::collections::HashSet<Bytes32>>,
+    ) -> Result<(Block, Self, Vec<Attestation>, BlockSignatures), String> {
+        Err("build_block is not implemented for devnet2".to_string())
     }
 }
 
@@ -726,14 +754,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "devnet1")]
     fn test_build_block() {
         // Create genesis state with validators
         let genesis_state = State::generate_genesis(Uint64(0), Uint64(4));
-        
+
         // Compute expected parent root after slot processing
         let pre_state = genesis_state.process_slots(Slot(1)).unwrap();
         let expected_parent_root = hash_tree_root(&pre_state.latest_block_header);
-        
+
         // Test 1: Build a simple block without attestations
         let result = genesis_state.build_block(
             Slot(1),
@@ -743,27 +772,34 @@ mod tests {
             None,
             None,
         );
-        
+
         assert!(result.is_ok(), "Building simple block should succeed");
         let (block, post_state, attestations, signatures) = result.unwrap();
-        
+
         // Verify block properties
         assert_eq!(block.slot, Slot(1));
         assert_eq!(block.proposer_index, ValidatorIndex(1));
         assert_eq!(block.parent_root, expected_parent_root);
-        assert_ne!(block.state_root, Bytes32(ssz::H256::zero()), "State root should be computed");
-        
+        assert_ne!(
+            block.state_root,
+            Bytes32(ssz::H256::zero()),
+            "State root should be computed"
+        );
+
         // Verify attestations and signatures are empty
         assert_eq!(attestations.len(), 0);
         // Check signatures by trying to get first element
         assert!(signatures.get(0).is_err(), "Signatures should be empty");
-        
+
         // Verify post-state has advanced
         assert_eq!(post_state.slot, Slot(1));
         // Note: The post-state's latest_block_header.state_root is zero because it will be
         // filled in during the next slot processing
-        assert_eq!(block.parent_root, expected_parent_root, "Parent root should match");
-        
+        assert_eq!(
+            block.parent_root, expected_parent_root,
+            "Parent root should match"
+        );
+
         // Test 2: Build block with initial attestations
         let attestation = Attestation {
             validator_id: Uint64(0),
@@ -783,7 +819,7 @@ mod tests {
                 },
             },
         };
-        
+
         let result = genesis_state.build_block(
             Slot(1),
             ValidatorIndex(1),
@@ -792,45 +828,48 @@ mod tests {
             None,
             None,
         );
-        
-        assert!(result.is_ok(), "Building block with attestations should succeed");
+
+        assert!(
+            result.is_ok(),
+            "Building block with attestations should succeed"
+        );
         let (block, _post_state, attestations, _signatures) = result.unwrap();
-        
+
         // Verify attestation was included
         assert_eq!(attestations.len(), 1);
         assert_eq!(attestations[0].validator_id, Uint64(0));
         // Check that attestation list has one element
-        assert!(block.body.attestations.get(0).is_ok(), "Block should contain attestation");
-        assert!(block.body.attestations.get(1).is_err(), "Block should have only one attestation");
+        assert!(
+            block.body.attestations.get(0).is_ok(),
+            "Block should contain attestation"
+        );
+        assert!(
+            block.body.attestations.get(1).is_err(),
+            "Block should have only one attestation"
+        );
     }
 
     #[test]
     fn test_build_block_advances_state() {
         // Create genesis state
         let genesis_state = State::generate_genesis(Uint64(0), Uint64(10));
-        
+
         // Compute parent root after advancing to target slot
         let pre_state = genesis_state.process_slots(Slot(5)).unwrap();
         let parent_root = hash_tree_root(&pre_state.latest_block_header);
-        
+
         // Build block at slot 5
         // Proposer for slot 5 with 10 validators is (5 % 10) = 5
-        let result = genesis_state.build_block(
-            Slot(5),
-            ValidatorIndex(5),
-            parent_root,
-            None,
-            None,
-            None,
-        );
-        
+        let result =
+            genesis_state.build_block(Slot(5), ValidatorIndex(5), parent_root, None, None, None);
+
         assert!(result.is_ok());
         let (block, post_state, _, _) = result.unwrap();
-        
+
         // Verify state advanced through slots
         assert_eq!(post_state.slot, Slot(5));
         assert_eq!(block.slot, Slot(5));
-        
+
         // Verify block can be applied to genesis state
         let transition_result = genesis_state.state_transition_with_validation(
             SignedBlockWithAttestation {
@@ -838,49 +877,45 @@ mod tests {
                     block: block.clone(),
                     proposer_attestation: Attestation::default(),
                 },
-                signature: BlockSignatures::default(),
+                signature: PersistentList::default(),
             },
             true, // signatures are considered valid (not validating, just marking as valid)
             true,
         );
-        
-        assert!(transition_result.is_ok(), "Built block should be valid for state transition");
+
+        assert!(
+            transition_result.is_ok(),
+            "Built block should be valid for state transition"
+        );
     }
 
     #[test]
     fn test_build_block_state_root_matches() {
         // Create genesis state
         let genesis_state = State::generate_genesis(Uint64(0), Uint64(3));
-        
+
         // Compute parent root after advancing to target slot
         let pre_state = genesis_state.process_slots(Slot(1)).unwrap();
         let parent_root = hash_tree_root(&pre_state.latest_block_header);
-        
+
         // Build a block
         // Proposer for slot 1 with 3 validators is (1 % 3) = 1
-        let result = genesis_state.build_block(
-            Slot(1),
-            ValidatorIndex(1),
-            parent_root,
-            None,
-            None,
-            None,
-        );
-        
+        let result =
+            genesis_state.build_block(Slot(1), ValidatorIndex(1), parent_root, None, None, None);
+
         assert!(result.is_ok());
         let (block, post_state, _, _) = result.unwrap();
-        
+
         // Verify the state root in block matches the computed post-state
         let computed_state_root = hash_tree_root(&post_state);
         assert_eq!(
-            block.state_root, 
-            computed_state_root,
+            block.state_root, computed_state_root,
             "Block state root should match computed post-state root"
         );
-        
+
         // Verify it's not zero
         assert_ne!(
-            block.state_root, 
+            block.state_root,
             Bytes32(ssz::H256::zero()),
             "State root should not be zero"
         );

--- a/lean_client/containers/src/state.rs
+++ b/lean_client/containers/src/state.rs
@@ -1,5 +1,5 @@
 use crate::validator::Validator;
-use crate::{block::{hash_tree_root, Block, BlockBody, BlockHeader, SignedBlockWithAttestation}, Attestation, Attestations, Bytes32, Checkpoint, Config, Signature, Slot, Uint64, ValidatorIndex};
+use crate::{block::{hash_tree_root, Block, BlockBody, BlockHeader, SignedBlockWithAttestation}, Attestation, Attestations, Bytes32, Checkpoint, Config, Signature, SignedAttestation, Slot, Uint64, ValidatorIndex};
 use crate::{
     HistoricalBlockHashes, JustificationRoots, JustificationsValidators, JustifiedSlots, Validators,
 };
@@ -686,7 +686,7 @@ impl State {
         _proposer_index: ValidatorIndex,
         _parent_root: Bytes32,
         _initial_attestations: Option<Vec<Attestation>>,
-        _available_signed_attestations: Option<&[SignedBlockWithAttestation]>,
+        _available_signed_attestations: Option<&[SignedAttestation]>,
         _known_block_roots: Option<&std::collections::HashSet<Bytes32>>,
     ) -> Result<(Block, Self, Vec<Attestation>, BlockSignatures), String> {
         Err("build_block is not implemented for devnet2".to_string())

--- a/lean_client/containers/src/state.rs
+++ b/lean_client/containers/src/state.rs
@@ -135,18 +135,7 @@ impl State {
 
     /// Simple RR proposer rule (round-robin).
     pub fn is_proposer(&self, index: ValidatorIndex) -> bool {
-        // Count validators by iterating (since PersistentList doesn't have len())
-        let mut num_validators: u64 = 0;
-        let mut i: u64 = 0;
-        loop {
-            match self.validators.get(i) {
-                Ok(_) => {
-                    num_validators += 1;
-                    i += 1;
-                }
-                Err(_) => break,
-            }
-        }
+        let num_validators = self.validators.len_u64();
 
         if num_validators == 0 {
             return false; // No validators
@@ -486,18 +475,7 @@ impl State {
                 if validator_id < votes.len() && !votes[validator_id] {
                     votes[validator_id] = true;
 
-                    // Count validators
-                    let mut num_validators: u64 = 0;
-                    let mut i: u64 = 0;
-                    loop {
-                        match self.validators.get(i) {
-                            Ok(_) => {
-                                num_validators += 1;
-                                i += 1;
-                            }
-                            Err(_) => break,
-                        }
-                    }
+                    let num_validators = self.validators.len_u64();
 
                     let count = votes.iter().filter(|&&v| v).count();
                     if 3 * count >= 2 * num_validators as usize {

--- a/lean_client/containers/tests/main.rs
+++ b/lean_client/containers/tests/main.rs
@@ -1,4 +1,4 @@
-// tests/main.rs - Test entry point
+// tests/lib - Test entry point
 mod debug_deserialize;
 mod unit_tests;
 mod test_vectors;

--- a/lean_client/containers/tests/test_vectors/block_processing.rs
+++ b/lean_client/containers/tests/test_vectors/block_processing.rs
@@ -2,6 +2,7 @@
 use super::runner::TestRunner;
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_process_first_block_after_genesis() {
     let test_path = "../tests/test_vectors/test_blocks/test_process_first_block_after_genesis.json";
     TestRunner::run_block_processing_test(test_path)
@@ -9,6 +10,7 @@ fn test_process_first_block_after_genesis() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_blocks_with_gaps() {
     let test_path = "../tests/test_vectors/test_blocks/test_blocks_with_gaps.json";
     TestRunner::run_block_processing_test(test_path)
@@ -16,6 +18,7 @@ fn test_blocks_with_gaps() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_linear_chain_multiple_blocks() {
     let test_path = "../tests/test_vectors/test_blocks/test_linear_chain_multiple_blocks.json";
     TestRunner::run_block_processing_test(test_path)
@@ -23,6 +26,7 @@ fn test_linear_chain_multiple_blocks() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_block_extends_deep_chain() {
     let test_path = "../tests/test_vectors/test_blocks/test_block_extends_deep_chain.json";
     TestRunner::run_block_processing_test(test_path)
@@ -30,6 +34,7 @@ fn test_block_extends_deep_chain() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_empty_blocks() {
     let test_path = "../tests/test_vectors/test_blocks/test_empty_blocks.json";
     TestRunner::run_block_processing_test(test_path)
@@ -37,6 +42,7 @@ fn test_empty_blocks() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_empty_blocks_with_missed_slots() {
     let test_path = "../tests/test_vectors/test_blocks/test_empty_blocks_with_missed_slots.json";
     TestRunner::run_block_processing_test(test_path)
@@ -44,6 +50,7 @@ fn test_empty_blocks_with_missed_slots() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_block_at_large_slot_number() {
     let test_path = "../tests/test_vectors/test_blocks/test_block_at_large_slot_number.json";
     TestRunner::run_block_processing_test(test_path)
@@ -53,6 +60,7 @@ fn test_block_at_large_slot_number() {
 // Invalid block tests (expecting failures)
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_block_with_invalid_parent_root() {
     let test_path = "../tests/test_vectors/test_blocks/test_block_with_invalid_parent_root.json";
     TestRunner::run_block_processing_test(test_path)
@@ -60,6 +68,7 @@ fn test_block_with_invalid_parent_root() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_block_with_invalid_proposer() {
     let test_path = "../tests/test_vectors/test_blocks/test_block_with_invalid_proposer.json";
     TestRunner::run_block_processing_test(test_path)
@@ -67,6 +76,7 @@ fn test_block_with_invalid_proposer() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_block_with_invalid_state_root() {
     let test_path = "../tests/test_vectors/test_blocks/test_block_with_invalid_state_root.json";
     TestRunner::run_block_processing_test(test_path)

--- a/lean_client/containers/tests/test_vectors/runner.rs
+++ b/lean_client/containers/tests/test_vectors/runner.rs
@@ -83,18 +83,7 @@ impl TestRunner {
 
                 // Only check validator count if specified in post-state
                 if let Some(expected_count) = post.validator_count {
-                    // Count validators
-                    let mut num_validators: u64 = 0;
-                    let mut i: u64 = 0;
-                    loop {
-                        match state.validators.get(i) {
-                            Ok(_) => {
-                                num_validators += 1;
-                                i += 1;
-                            }
-                            Err(_) => break,
-                        }
-                    }
+                    let num_validators = state.validators.len_u64();
                     
                     if num_validators as usize != expected_count {
                         return Err(format!(
@@ -436,18 +425,7 @@ impl TestRunner {
 
         let state = &test_case.pre;
         
-        // Count validators
-        let mut num_validators: u64 = 0;
-        let mut i: u64 = 0;
-        loop {
-            match state.validators.get(i) {
-                Ok(_) => {
-                    num_validators += 1;
-                    i += 1;
-                }
-                Err(_) => break,
-            }
-        }
+        let num_validators = state.validators.len_u64();
         println!("  Genesis time: {}, slot: {}, validators: {}", state.config.genesis_time, state.slot.0, num_validators);
         
         // Verify it's at genesis (slot 0)
@@ -555,17 +533,7 @@ impl TestRunner {
             
             // Verify validator count if specified
             if let Some(expected_count) = post.validator_count {
-                let mut num_validators: u64 = 0;
-                let mut i: u64 = 0;
-                loop {
-                    match state.validators.get(i) {
-                        Ok(_) => {
-                            num_validators += 1;
-                            i += 1;
-                        }
-                        Err(_) => break,
-                    }
-                }
+                let num_validators = state.validators.len_u64();
                 
                 if num_validators as usize != expected_count {
                     return Err(format!(

--- a/lean_client/containers/tests/test_vectors/runner.rs
+++ b/lean_client/containers/tests/test_vectors/runner.rs
@@ -552,6 +552,7 @@ impl TestRunner {
 
     /// Test runner for verify_signatures test vectors
     /// Tests XMSS signature verification on SignedBlockWithAttestation
+    #[cfg(feature = "devnet1")]
     pub fn run_verify_signatures_test<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::error::Error>> {
         let json_content = fs::read_to_string(path.as_ref())?;
         
@@ -571,25 +572,11 @@ impl TestRunner {
         println!("  Block slot: {}", signed_block.message.block.slot.0);
         println!("  Proposer index: {}", signed_block.message.block.proposer_index.0);
         
-        // Count attestations
-        let mut attestation_count = 0u64;
-        loop {
-            match signed_block.message.block.body.attestations.get(attestation_count) {
-                Ok(_) => attestation_count += 1,
-                Err(_) => break,
-            }
-        }
+        let attestation_count = signed_block.message.block.body.attestations.len_u64();
         println!("  Attestations in block: {}", attestation_count);
         println!("  Proposer attestation validator: {}", signed_block.message.proposer_attestation.validator_id.0);
         
-        // Count signatures
-        let mut signature_count = 0u64;
-        loop {
-            match signed_block.signature.get(signature_count) {
-                Ok(_) => signature_count += 1,
-                Err(_) => break,
-            }
-        }
+        let signature_count = signed_block.signature.len_u64();
         println!("  Signatures: {}", signature_count);
         
         // Check if we expect this test to fail

--- a/lean_client/containers/tests/test_vectors/verify_signatures.rs
+++ b/lean_client/containers/tests/test_vectors/verify_signatures.rs
@@ -15,6 +15,7 @@ use super::runner::TestRunner;
 // Without xmss-verify feature, they pass because structural validation succeeds.
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_proposer_signature() {
     let test_path = "../tests/test_vectors/test_verify_signatures/test_valid_signatures/test_proposer_signature.json";
     TestRunner::run_verify_signatures_test(test_path)
@@ -22,6 +23,7 @@ fn test_proposer_signature() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_proposer_and_attester_signatures() {
     let test_path = "../tests/test_vectors/test_verify_signatures/test_valid_signatures/test_proposer_and_attester_signatures.json";
     TestRunner::run_verify_signatures_test(test_path)
@@ -34,6 +36,7 @@ fn test_proposer_and_attester_signatures() {
 // Run with `cargo test --features xmss-verify` to enable full signature verification.
 
 #[test]
+#[cfg(feature = "devnet1")]
 #[ignore = "Requires xmss-verify feature for actual signature validation. Run with: cargo test --features xmss-verify"]
 fn test_invalid_signature() {
     let test_path = "../tests/test_vectors/test_verify_signatures/test_invalid_signatures/test_invalid_signature.json";
@@ -42,6 +45,7 @@ fn test_invalid_signature() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 #[ignore = "Requires xmss-verify feature for actual signature validation. Run with: cargo test --features xmss-verify"]
 fn test_mixed_valid_invalid_signatures() {
     let test_path = "../tests/test_vectors/test_verify_signatures/test_invalid_signatures/test_mixed_valid_invalid_signatures.json";

--- a/lean_client/containers/tests/unit_tests/attestation_aggregation.rs
+++ b/lean_client/containers/tests/unit_tests/attestation_aggregation.rs
@@ -1,0 +1,132 @@
+#[cfg(feature = "devnet2")]
+#[cfg(test)]
+mod tests {
+    use containers::attestation::{AggregatedAttestation, AggregationBits, Attestation, AttestationData};
+    use containers::{Bytes32, Uint64};
+    use containers::checkpoint::Checkpoint;
+    use containers::slot::Slot;
+
+    #[test]
+    fn test_aggregated_attestation_structure() {
+        let att_data = AttestationData {
+            slot: Slot(5),
+            head: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(4),
+            },
+            target: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(3),
+            },
+            source: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(2),
+            }
+        };
+
+        let bits = AggregationBits::from_validator_indices(&vec![2, 7]);
+        let agg = AggregatedAttestation {
+            aggregation_bits: bits.clone(),
+            data: att_data.clone()
+        };
+
+        let indices = agg.aggregation_bits.to_validator_indices();
+        assert_eq!(indices.into_iter().collect::<std::collections::HashSet<_>>(), vec![2, 7].into_iter().collect());
+        assert_eq!(agg.data, att_data);
+    }
+
+    #[test]
+    fn test_aggregate_attestations_by_common_data() {
+        let att_data1 = AttestationData {
+            slot: Slot(5),
+            head: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(4),
+            },
+            target: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(3),
+            },
+            source: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(2),
+            }
+        };
+        let att_data2 = AttestationData {
+            slot: Slot(6),
+            head: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(5),
+            },
+            target: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(4),
+            },
+            source: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(3),
+            }
+        };
+
+        let attestations = vec![
+            Attestation {
+                validator_id: Uint64(1),
+                data: att_data1.clone(),
+            },
+            Attestation {
+                validator_id: Uint64(3),
+                data: att_data1.clone(),
+            },
+            Attestation {
+                validator_id: Uint64(5),
+                data: att_data2.clone(),
+            },
+        ];
+
+        let aggregated = AggregatedAttestation::aggregate_by_data(&attestations);
+        assert_eq!(aggregated.len(), 2);
+
+        let agg1 = aggregated.iter().find(|agg| agg.data == att_data1).unwrap();
+        let validator_ids1 = agg1.aggregation_bits.to_validator_indices();
+        assert_eq!(validator_ids1.into_iter().collect::<std::collections::HashSet<_>>(), vec![1, 3].into_iter().collect());
+
+        let agg2 = aggregated.iter().find(|agg| agg.data == att_data2).unwrap();
+        let validator_ids2 = agg2.aggregation_bits.to_validator_indices();
+        assert_eq!(validator_ids2, vec![5]);
+    }
+
+    #[test]
+    fn test_aggregate_empty_attestations() {
+        let aggregated = AggregatedAttestation::aggregate_by_data(&[]);
+        assert!(aggregated.is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_single_attestation() {
+        let att_data = AttestationData {
+            slot: Slot(5),
+            head: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(4),
+            },
+            target: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(3),
+            },
+            source: Checkpoint {
+                root: Bytes32::default(),
+                slot: Slot(2),
+            }
+        };
+
+        let attestations = vec![Attestation {
+            validator_id: Uint64(5),
+            data: att_data.clone(),
+        }];
+        let aggregated = AggregatedAttestation::aggregate_by_data(&attestations);
+
+        assert_eq!(aggregated.len(), 1);
+        let validator_ids = aggregated[0].aggregation_bits.to_validator_indices();
+        assert_eq!(validator_ids, vec![5]);
+    }
+}

--- a/lean_client/containers/tests/unit_tests/common.rs
+++ b/lean_client/containers/tests/unit_tests/common.rs
@@ -1,7 +1,7 @@
 use containers::{
-    Attestation, Attestations, BlockSignatures, BlockWithAttestation, Config, SignedBlockWithAttestation, block::{Block, BlockBody, BlockHeader, hash_tree_root}, checkpoint::Checkpoint, slot::Slot, state::State, types::{Bytes32, ValidatorIndex}, Validators
+    Attestation, Attestations, BlockWithAttestation, Config, SignedBlockWithAttestation, block::{Block, BlockBody, BlockHeader, hash_tree_root}, checkpoint::Checkpoint, slot::Slot, state::State, types::{Bytes32, ValidatorIndex}, Validators
 };
-use ssz::PersistentList as List;
+use ssz::{PersistentList};
 
 pub const DEVNET_CONFIG_VALIDATOR_REGISTRY_LIMIT: usize = 1 << 12; // 4096
 pub const TEST_VALIDATOR_COUNT: usize = 4; // Actual validator count used in tests
@@ -12,7 +12,7 @@ const _: [(); DEVNET_CONFIG_VALIDATOR_REGISTRY_LIMIT - TEST_VALIDATOR_COUNT] =
 
 pub fn create_block(slot: u64, parent_header: &mut BlockHeader, attestations: Option<Attestations>) -> SignedBlockWithAttestation {
     let body = BlockBody {
-        attestations: attestations.unwrap_or_else(List::default),
+        attestations: attestations.unwrap_or_else(PersistentList::default),
     };
 
     let block_message = Block {
@@ -28,7 +28,7 @@ pub fn create_block(slot: u64, parent_header: &mut BlockHeader, attestations: Op
             block: block_message,
             proposer_attestation: Attestation::default(),
         },
-        signature: BlockSignatures::default(),
+        signature: PersistentList::default(),
     }
 }
 

--- a/lean_client/containers/tests/unit_tests/mod.rs
+++ b/lean_client/containers/tests/unit_tests/mod.rs
@@ -4,3 +4,4 @@ mod state_basic;
 mod state_justifications;
 mod state_process;
 mod state_transition;
+mod attestation_aggregation;

--- a/lean_client/containers/tests/unit_tests/state_process.rs
+++ b/lean_client/containers/tests/unit_tests/state_process.rs
@@ -106,6 +106,7 @@ fn test_process_block_header_invalid(
 }
 
 // This test verifies that attestations correctly justify and finalize slots
+#[cfg(feature = "devnet1")]
 #[test]
 fn test_process_attestations_justification_and_finalization() {
     let mut state = genesis_state();

--- a/lean_client/containers/tests/unit_tests/state_transition.rs
+++ b/lean_client/containers/tests/unit_tests/state_transition.rs
@@ -3,10 +3,11 @@ use containers::{
     block::{Block, SignedBlockWithAttestation, BlockWithAttestation, hash_tree_root},
     state::State,
     types::{Bytes32, Uint64},
-    Slot, Attestation, BlockSignatures
+    Slot, Attestation
 };
 use pretty_assertions::assert_eq;
 use rstest::fixture;
+use ssz::PersistentList;
 
 #[path = "common.rs"]
 mod common;
@@ -78,6 +79,7 @@ fn test_state_transition_invalid_signatures() {
     assert_eq!(result.unwrap_err(), "Block signatures must be valid");
 }
 
+#[cfg(feature = "devnet1")]
 #[test]
 fn test_state_transition_bad_state_root() {
     let state = genesis_state();
@@ -93,7 +95,7 @@ fn test_state_transition_bad_state_root() {
             block,
             proposer_attestation: Attestation::default(),
         },
-        signature: BlockSignatures::default(),
+        signature: PersistentList::default(),
     };
 
     let result = state.state_transition(final_signed_block_with_attestation, true);

--- a/lean_client/containers/tests/unit_tests/state_transition.rs
+++ b/lean_client/containers/tests/unit_tests/state_transition.rs
@@ -1,9 +1,9 @@
 // tests/state_transition.rs
 use containers::{
-    block::{Block, SignedBlockWithAttestation, BlockWithAttestation, hash_tree_root},
+    block::{hash_tree_root, Block, BlockWithAttestation, SignedBlockWithAttestation},
     state::State,
     types::{Bytes32, Uint64},
-    Slot, Attestation
+    Attestation, Attestations, Slot,
 };
 use pretty_assertions::assert_eq;
 use rstest::fixture;
@@ -24,12 +24,28 @@ fn test_state_transition_full() {
     let state = genesis_state();
     let mut state_at_slot_1 = state.process_slots(Slot(1)).unwrap();
 
-    let signed_block_with_attestation = create_block(1, &mut state_at_slot_1.latest_block_header, None);
+    let signed_block_with_attestation =
+        create_block(1, &mut state_at_slot_1.latest_block_header, None);
     let block = signed_block_with_attestation.message.block.clone();
 
     // Use process_block_header + process_operations to avoid state root validation during setup
     let state_after_header = state_at_slot_1.process_block_header(&block).unwrap();
+
+    #[cfg(feature = "devnet1")]
     let expected_state = state_after_header.process_attestations(&block.body.attestations);
+
+    #[cfg(feature = "devnet2")]
+    let expected_state = {
+        let mut unaggregated_attestations = Attestations::default();
+        for aggregated_attestation in &block.body.attestations {
+            let plain_attestations = aggregated_attestation.to_plain();
+            // For each attestatio in the vector, push to the list
+            for attestation in plain_attestations {
+                unaggregated_attestations.push(attestation);
+            }
+        }
+        state_after_header.process_attestations(&unaggregated_attestations)
+    };
 
     let block_with_correct_root = Block {
         state_root: hash_tree_root(&expected_state),
@@ -44,7 +60,9 @@ fn test_state_transition_full() {
         signature: signed_block_with_attestation.signature,
     };
 
-    let final_state = state.state_transition(final_signed_block_with_attestation, true).unwrap();
+    let final_state = state
+        .state_transition(final_signed_block_with_attestation, true)
+        .unwrap();
 
     assert_eq!(final_state, expected_state);
 }
@@ -54,12 +72,28 @@ fn test_state_transition_invalid_signatures() {
     let state = genesis_state();
     let mut state_at_slot_1 = state.process_slots(Slot(1)).unwrap();
 
-    let signed_block_with_attestation = create_block(1, &mut state_at_slot_1.latest_block_header, None);
+    let signed_block_with_attestation =
+        create_block(1, &mut state_at_slot_1.latest_block_header, None);
     let block = signed_block_with_attestation.message.block.clone();
 
     // Use process_block_header + process_operations to avoid state root validation during setup
     let state_after_header = state_at_slot_1.process_block_header(&block).unwrap();
+
+    #[cfg(feature = "devnet1")]
     let expected_state = state_after_header.process_attestations(&block.body.attestations);
+
+    #[cfg(feature = "devnet2")]
+    let expected_state = {
+        let mut list = Attestations::default();
+        for aggregated_attestation in &block.body.attestations {
+            let plain_attestations = aggregated_attestation.to_plain();
+            // For each attestatio in the vector, push to the list
+            for attestation in plain_attestations {
+                list.push(attestation);
+            }
+        }
+        list
+    };
 
     let block_with_correct_root = Block {
         state_root: hash_tree_root(&expected_state),
@@ -85,7 +119,8 @@ fn test_state_transition_bad_state_root() {
     let state = genesis_state();
     let mut state_at_slot_1 = state.process_slots(Slot(1)).unwrap();
 
-    let signed_block_with_attestation = create_block(1, &mut state_at_slot_1.latest_block_header, None);
+    let signed_block_with_attestation =
+        create_block(1, &mut state_at_slot_1.latest_block_header, None);
     let mut block = signed_block_with_attestation.message.block.clone();
 
     block.state_root = Bytes32(ssz::H256::zero());
@@ -101,4 +136,56 @@ fn test_state_transition_bad_state_root() {
     let result = state.state_transition(final_signed_block_with_attestation, true);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), "Invalid block state root");
+}
+
+#[cfg(feature = "devnet2")]
+#[test]
+fn test_state_transition_devnet2() {
+    let state = genesis_state();
+    let mut state_at_slot_1 = state.process_slots(Slot(1)).unwrap();
+
+    // Create a block with attestations for devnet2
+    let signed_block_with_attestation =
+        create_block(1, &mut state_at_slot_1.latest_block_header, None);
+    let block = signed_block_with_attestation.message.block.clone();
+
+    // Process the block header and attestations
+    let state_after_header = state_at_slot_1.process_block_header(&block).unwrap();
+
+    #[cfg(feature = "devnet1")]
+    let expected_state = state_after_header.process_attestations(&block.body.attestations);
+
+    #[cfg(feature = "devnet2")]
+    let expected_state = {
+        let mut unaggregated_attestations = Attestations::default();
+        for aggregated_attestation in &block.body.attestations {
+            let plain_attestations = aggregated_attestation.to_plain();
+            // For each attestatio in the vector, push to the list
+            for attestation in plain_attestations {
+                unaggregated_attestations.push(attestation);
+            }
+        }
+        state_after_header.process_attestations(&unaggregated_attestations)
+    };
+    
+    // Ensure the state root matches the expected state
+    let block_with_correct_root = Block {
+        state_root: hash_tree_root(&expected_state),
+        ..block
+    };
+
+    let final_signed_block_with_attestation = SignedBlockWithAttestation {
+        message: BlockWithAttestation {
+            block: block_with_correct_root,
+            proposer_attestation: signed_block_with_attestation.message.proposer_attestation,
+        },
+        signature: signed_block_with_attestation.signature,
+    };
+
+    // Perform the state transition and validate the result
+    let final_state = state
+        .state_transition(final_signed_block_with_attestation, true)
+        .unwrap();
+
+    assert_eq!(final_state, expected_state);
 }

--- a/lean_client/env-config/Cargo.toml
+++ b/lean_client/env-config/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "env-config"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[features]
+devnet1 = []
+devnet2 = []
+
+[dependencies]

--- a/lean_client/env-config/src/lib.rs
+++ b/lean_client/env-config/src/lib.rs
@@ -1,0 +1,1 @@
+// Empty on purpose

--- a/lean_client/fork_choice/Cargo.toml
+++ b/lean_client/fork_choice/Cargo.toml
@@ -3,8 +3,14 @@ name = "fork-choice"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+devnet1 = ["containers/devnet1", "env-config/devnet1"]
+devnet2 = ["containers/devnet2", "env-config/devnet1"]
+
 [dependencies]
-containers = { path = "../containers" }
+env-config = { path = "../env-config", default-features = false }
+containers = { path = "../containers", default-features = false }
 ssz = { git = "https://github.com/grandinetech/grandine", package = "ssz", branch = "develop"}
 ssz_derive = { git = "https://github.com/grandinetech/grandine", package = "ssz_derive", branch = "develop" }
 typenum = "1.17.0"

--- a/lean_client/fork_choice/src/store.rs
+++ b/lean_client/fork_choice/src/store.rs
@@ -85,7 +85,10 @@ pub fn get_fork_choice_head(
 
     // stage 1: accumulate weights by walking up from each attestation's head
     for attestation in latest_attestations.values() {
+        #[cfg(feature = "devnet1")]
         let mut curr = attestation.message.data.head.root;
+        #[cfg(feature = "devnet2")]
+        let mut curr = attestation.message.head.root;
 
         if let Some(block) = store.blocks.get(&curr) {
             let mut curr_slot = block.message.block.slot;

--- a/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
+++ b/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
@@ -4,7 +4,7 @@ use fork_choice::{
 };
 
 use containers::{
-    attestation::{Attestation, AttestationData, BlockSignatures, SignedAttestation, Signature},
+    attestation::{Attestation, AttestationData, SignedAttestation, Signature},
     block::{hash_tree_root, Block, BlockBody, BlockHeader, BlockWithAttestation, SignedBlockWithAttestation},
     checkpoint::Checkpoint,
     config::Config,
@@ -13,7 +13,7 @@ use containers::{
 };
 
 use serde::Deserialize;
-use ssz::SszHash;
+use ssz::{PersistentList, SszHash};
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 
@@ -299,7 +299,7 @@ fn convert_test_anchor_block(test_block: &TestAnchorBlock) -> SignedBlockWithAtt
             block,
             proposer_attestation,
         },
-        signature: BlockSignatures::default(),
+        signature: PersistentList::default(),
     }
 }
 
@@ -329,7 +329,7 @@ fn convert_test_block(test_block_with_att: &TestBlockWithAttestation) -> SignedB
             block,
             proposer_attestation,
         },
-        signature: BlockSignatures::default(),
+        signature: PersistentList::default(),
     }
 }
 

--- a/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
+++ b/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
@@ -256,6 +256,7 @@ fn convert_test_attestation(test_att: &TestAttestation) -> Attestation {
     }
 }
 
+#[cfg(feature = "devnet1")]
 fn convert_test_anchor_block(test_block: &TestAnchorBlock) -> SignedBlockWithAttestation {
     let mut attestations = ssz::PersistentList::default();
 
@@ -303,6 +304,7 @@ fn convert_test_anchor_block(test_block: &TestAnchorBlock) -> SignedBlockWithAtt
     }
 }
 
+#[cfg(feature = "devnet1")]
 fn convert_test_block(test_block_with_att: &TestBlockWithAttestation) -> SignedBlockWithAttestation {
     let test_block = &test_block_with_att.block;
     let mut attestations = ssz::PersistentList::default();
@@ -405,6 +407,7 @@ fn initialize_state_from_test(test_state: &TestAnchorState) -> State {
     }
 }
 
+#[cfg(feature = "devnet1")]
 fn verify_checks(
     store: &Store,
     checks: &Option<TestChecks>,
@@ -493,6 +496,7 @@ fn verify_checks(
     Ok(())
 }
 
+#[cfg(feature = "devnet1")]
 fn run_single_test(_test_name: &str, test: TestVector) -> Result<(), String> {
     println!("  Running: {}", test.info.test_id);
 
@@ -624,6 +628,7 @@ fn run_single_test(_test_name: &str, test: TestVector) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(feature = "devnet1")]
 fn run_test_vector_file(test_path: &str) -> Result<(), String> {
     let json_str = std::fs::read_to_string(test_path)
         .map_err(|e| format!("Failed to read file {}: {}", test_path, e))?;
@@ -639,6 +644,7 @@ fn run_test_vector_file(test_path: &str) -> Result<(), String> {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_fork_choice_head_vectors() {
     let test_dir = "../tests/test_vectors/test_fork_choice/test_fork_choice_head";
 
@@ -682,6 +688,7 @@ fn test_fork_choice_head_vectors() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_attestation_processing_vectors() {
     let test_dir = "../tests/test_vectors/test_fork_choice/test_attestation_processing";
 
@@ -725,6 +732,7 @@ fn test_attestation_processing_vectors() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_fork_choice_reorgs_vectors() {
     let test_dir = "../tests/test_vectors/test_fork_choice/test_fork_choice_reorgs";
 
@@ -768,6 +776,7 @@ fn test_fork_choice_reorgs_vectors() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_attestation_target_selection_vectors() {
     let test_dir = "../tests/test_vectors/test_fork_choice/test_attestation_target_selection";
 
@@ -811,6 +820,7 @@ fn test_attestation_target_selection_vectors() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_lexicographic_tiebreaker_vectors() {
     let test_dir = "../tests/test_vectors/test_fork_choice/test_lexicographic_tiebreaker";
 

--- a/lean_client/fork_choice/tests/unit_tests/votes.rs
+++ b/lean_client/fork_choice/tests/unit_tests/votes.rs
@@ -7,6 +7,7 @@ use containers::{
     Bytes32, Slot, Uint64, ValidatorIndex,
 };
 
+#[cfg(feature = "devnet1")]
 fn create_signed_attestation(validator_id: u64, slot: Slot, head_root: Bytes32) -> SignedAttestation {
     SignedAttestation {
         message: Attestation {
@@ -23,6 +24,7 @@ fn create_signed_attestation(validator_id: u64, slot: Slot, head_root: Bytes32) 
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_accept_new_attestations() {
     let mut store = create_test_store();
 
@@ -63,6 +65,7 @@ fn test_accept_new_attestations() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_accept_new_attestations_multiple() {
     let mut store = create_test_store();
     
@@ -94,6 +97,7 @@ fn test_accept_new_attestations_empty() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_on_attestation_lifecycle() {
     let mut store = create_test_store();
     let validator_idx = ValidatorIndex(1);
@@ -129,6 +133,7 @@ fn test_on_attestation_lifecycle() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_on_attestation_future_slot() {
     let mut store = create_test_store();
     let future_slot = Slot(100); // Far in the future
@@ -140,6 +145,7 @@ fn test_on_attestation_future_slot() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_on_attestation_update_vote() {
     let mut store = create_test_store();
     let validator_idx = ValidatorIndex(1);
@@ -161,6 +167,7 @@ fn test_on_attestation_update_vote() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_on_attestation_ignore_old_vote() {
     let mut store = create_test_store();
     let validator_idx = ValidatorIndex(1);
@@ -183,6 +190,7 @@ fn test_on_attestation_ignore_old_vote() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_on_attestation_from_block_supersedes_new() {
     let mut store = create_test_store();
     let validator_idx = ValidatorIndex(1);
@@ -204,6 +212,7 @@ fn test_on_attestation_from_block_supersedes_new() {
 }
 
 #[test]
+#[cfg(feature = "devnet1")]
 fn test_on_attestation_newer_from_block_removes_older_new() {
     let mut store = create_test_store();
     let validator_idx = ValidatorIndex(1);

--- a/lean_client/networking/Cargo.toml
+++ b/lean_client/networking/Cargo.toml
@@ -3,7 +3,13 @@ name = "networking"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+devnet1 = ["containers/devnet1", "env-config/devnet1"]
+devnet2 = ["containers/devnet2", "env-config/devnet1"]
+
 [dependencies]
+env-config = { path = "../env-config", default-features = false }
 containers = {workspace = true}
 alloy-primitives = { workspace = true}
 libp2p = {workspace = true}

--- a/lean_client/networking/src/network/service.rs
+++ b/lean_client/networking/src/network/service.rs
@@ -311,7 +311,10 @@ where
                         }
                     }
                     Ok(GossipsubMessage::Attestation(signed_attestation)) => {
+                        #[cfg(feature = "devnet1")]
                         let slot = signed_attestation.message.data.slot.0;
+                        #[cfg(feature = "devnet2")]
+                        let slot = signed_attestation.message.slot.0;
 
                         if let Err(err) = self
                             .chain_message_sink
@@ -521,7 +524,11 @@ where
                 }
             }
             OutboundP2pRequest::GossipAttestation(signed_attestation) => {
+                #[cfg(feature = "devnet1")]
                 let slot = signed_attestation.message.data.slot.0;
+                #[cfg(feature = "devnet2")]
+                let slot = signed_attestation.message.slot.0;
+                
                 match signed_attestation.to_ssz() {
                     Ok(bytes) => {
                         if let Err(err) = self.publish_to_topic(GossipsubKind::Attestation, bytes) {

--- a/lean_client/networking/src/types.rs
+++ b/lean_client/networking/src/types.rs
@@ -93,8 +93,13 @@ impl Display for ChainMessage {
             ChainMessage::ProcessBlock { signed_block_with_attestation, .. } => {
                 write!(f, "ProcessBlockWithAttestation(slot={})", signed_block_with_attestation.message.block.slot.0)
             }
+            #[cfg(feature = "devnet1")]
             ChainMessage::ProcessAttestation { signed_attestation, .. } => {
                 write!(f, "ProcessAttestation(slot={})", signed_attestation.message.data.slot.0)
+            }
+            #[cfg(feature = "devnet2")]
+            ChainMessage::ProcessAttestation { signed_attestation, .. } => {
+                write!(f, "ProcessAttestation(slot={})", signed_attestation.message.slot.0)
             }
         }
     }

--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use containers::ssz::SszHash;
+use containers::ssz::{PersistentList, SszHash};
 use containers::{
-    attestation::{Attestation, AttestationData, BlockSignatures},
+    attestation::{Attestation, AttestationData},
     block::{Block, BlockBody, BlockWithAttestation, SignedBlockWithAttestation},
     checkpoint::Checkpoint,
     config::Config,
@@ -216,7 +216,7 @@ async fn main() {
             block: genesis_block,
             proposer_attestation: genesis_proposer_attestation,
         },
-        signature: BlockSignatures::default(),
+        signature: PersistentList::default(),
     };
 
     let config = Config { genesis_time };

--- a/lean_client/validator/Cargo.toml
+++ b/lean_client/validator/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2021"
 [features]
 default = ["xmss-signing"]
 xmss-signing = ["leansig"]
+devnet1 = ["containers/devnet1", "fork-choice/devnet1", "env-config/devnet1"]
+devnet2 = ["containers/devnet2", "fork-choice/devnet2", "env-config/devnet1"]
 
 [dependencies]
+env-config = { path = "../env-config", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 containers = { path = "../containers" }

--- a/lean_client/validator/src/lib.rs
+++ b/lean_client/validator/src/lib.rs
@@ -2,12 +2,16 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use containers::attestation::{AggregatedAttestations};
+#[cfg(feature = "devnet2")]
+use containers::attestation::{NaiveAggregatedSignature};
+use containers::block::BlockSignatures;
 use containers::{
     attestation::{Attestation, AttestationData, Signature, SignedAttestation},
-    block::{BlockWithAttestation, SignedBlockWithAttestation, hash_tree_root},
+    block::{hash_tree_root, BlockWithAttestation, SignedBlockWithAttestation},
     checkpoint::Checkpoint,
     types::{Uint64, ValidatorIndex},
-    Slot,
+    AggregatedAttestation, Slot,
 };
 use fork_choice::store::{get_proposal_head, get_vote_target, Store};
 use tracing::{info, warn};
@@ -172,19 +176,29 @@ impl ValidatorService {
             .latest_new_attestations
             .values()
             .filter(|att| {
+                #[cfg(feature = "devnet1")]
                 let data = &att.message.data;
+                #[cfg(feature = "devnet2")]
+                let data = &att.message;
                 // Source must match the parent state's justified checkpoint (not store's!)
                 let source_matches = data.source == parent_state.latest_justified;
                 // Target must be strictly after source
                 let target_after_source = data.target.slot > data.source.slot;
                 // Target block must be known
                 let target_known = store.blocks.contains_key(&data.target.root);
-                
+
                 source_matches && target_after_source && target_known
             })
             .collect();
 
+        #[cfg(feature = "devnet1")]
         let valid_attestations: Vec<Attestation> = valid_signed_attestations
+            .iter()
+            .map(|att| att.message.clone())
+            .collect();
+
+        #[cfg(feature = "devnet2")]
+        let valid_attestations: Vec<AttestationData> = valid_signed_attestations
             .iter()
             .map(|att| att.message.clone())
             .collect();
@@ -197,14 +211,52 @@ impl ValidatorService {
         );
 
         // Build block with collected attestations (empty body - attestations go to state)
-        let (block, _post_state, _collected_atts, sigs) =
-            parent_state.build_block(slot, proposer_index, parent_root, Some(valid_attestations), None, None)?;
+        #[cfg(feature = "devnet1")]
+        let (block, _post_state, _collected_atts, sigs) = parent_state.build_block(
+            slot,
+            proposer_index,
+            parent_root,
+            Some(valid_attestations),
+            None,
+            None,
+        )?;
+        #[cfg(feature = "devnet2")]
+        let (block, _post_state, _collected_atts, sigs) = {
+            let valid_attestations: Vec<Attestation> = valid_attestations
+                .iter()
+                .map(|data| Attestation {
+                    validator_id: Uint64(0), // Placeholder, real validator IDs should be used
+                    data: data.clone(),
+                })
+                .collect();
+            parent_state.build_block(
+                slot,
+                proposer_index,
+                parent_root,
+                Some(valid_attestations),
+                None,
+                None,
+            )?
+        };
 
         // Collect signatures from the attestations we included
+        #[cfg(feature = "devnet1")]
         let mut signatures = sigs;
+        #[cfg(feature = "devnet2")]
+        let mut signatures = sigs.attestation_signatures;
         for signed_att in &valid_signed_attestations {
-            signatures.push(signed_att.signature.clone())
+            #[cfg(feature = "devnet1")]
+            signatures
+                .push(signed_att.signature.clone())
                 .map_err(|e| format!("Failed to add attestation signature: {:?}", e))?;
+            #[cfg(feature = "devnet2")]
+            {
+                // TODO: Use real aggregation instead of naive placeholder when spec is more up to date
+                let aggregated_sig: NaiveAggregatedSignature = NaiveAggregatedSignature::default();
+                signatures
+                    .push(aggregated_sig)
+                    .map_err(|e| format!("Failed to add attestation signature: {:?}", e))?;
+            }
         }
 
         info!(
@@ -224,11 +276,20 @@ impl ValidatorService {
 
             match key_manager.sign(proposer_index.0, epoch, &message.0.into()) {
                 Ok(sig) => {
-                    signatures.push(sig).map_err(|e| format!("Failed to add proposer signature: {:?}", e))?;
-                    info!(
-                        proposer = proposer_index.0,
-                        "Signed proposer attestation"
-                    );
+                    #[cfg(feature = "devnet1")]
+                    signatures
+                        .push(sig)
+                        .map_err(|e| format!("Failed to add proposer signature: {:?}", e))?;
+                    #[cfg(feature = "devnet2")]
+                    {
+                        // TODO: Use real aggregation instead of naive placeholder when spec is more up to date
+                        let aggregated_sig: NaiveAggregatedSignature =
+                            NaiveAggregatedSignature::default();
+                        signatures
+                            .push(aggregated_sig)
+                            .map_err(|e| format!("Failed to add proposer signature: {:?}", e))?;
+                    }
+                    info!(proposer = proposer_index.0, "Signed proposer attestation");
                 }
                 Err(e) => {
                     return Err(format!("Failed to sign proposer attestation: {}", e));
@@ -244,7 +305,13 @@ impl ValidatorService {
                 block,
                 proposer_attestation,
             },
+            #[cfg(feature = "devnet1")]
             signature: signatures,
+            #[cfg(feature = "devnet2")]
+            signature: BlockSignatures {
+                attestation_signatures: signatures,
+                proposer_signature: Signature::default(),
+            },
         };
 
         Ok(signed_block)
@@ -284,6 +351,7 @@ impl ValidatorService {
             .validator_indices
             .iter()
             .filter_map(|&idx| {
+                #[cfg(feature = "devnet1")]
                 let attestation = Attestation {
                     validator_id: Uint64(idx),
                     data: AttestationData {
@@ -292,6 +360,14 @@ impl ValidatorService {
                         target: vote_target.clone(),
                         source: store.latest_justified.clone(),
                     },
+                };
+
+                #[cfg(feature = "devnet2")]
+                let attestation = AttestationData {
+                    slot,
+                    head: head_checkpoint.clone(),
+                    target: vote_target.clone(),
+                    source: store.latest_justified.clone(),
                 };
 
                 let signature = if let Some(ref key_manager) = self.key_manager {
@@ -331,10 +407,24 @@ impl ValidatorService {
                     Signature::default()
                 };
 
-                Some(SignedAttestation {
-                    message: attestation,
-                    signature,
-                })
+                {
+                    #[cfg(feature = "devnet1")]
+                    {
+                        Some(SignedAttestation {
+                            message: attestation,
+                            signature,
+                        })
+                    }
+
+                    #[cfg(feature = "devnet2")]
+                    {
+                        Some(SignedAttestation {
+                            validator_id: idx,
+                            message: attestation,
+                            signature,
+                        })
+                    }
+                }
             })
             .collect()
     }


### PR DESCRIPTION
- prepared container types according to updated leanSpec as outlined in this commit (https://github.com/leanEthereum/leanSpec/commit/5e6f3b08ddca5ebe03c2bd9ea854bd7a429416e9#diff-e97c19056d670da1fe3d87e05a2ec3025f020096b91bde26d355db8c3a7258d6)
- minor cleanups, refactored code to use len_u64() of PersistentList class as mentioned in this issue (https://github.com/grandinetech/lean/issues/30)
- added tests and feature configuration to switch between devnet1 and devnet2