### PR TITLE
Add rust-toolchain.toml (Rust 1.92)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+﻿[toolchain]
+channel = "1.92"


### PR DESCRIPTION
Fixes #22.

Adds rust-toolchain.toml to pin toolchain to Rust 1.92.