### PR TITLE
[29] - Fix validator public key

### DIFF
--- a/lean_client/containers/src/block.rs
+++ b/lean_client/containers/src/block.rs
@@ -7,7 +7,6 @@ use leansig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to
 use ssz::{PersistentList, SszHash};
 use typenum::U4096;
 use crate::attestation::{AggregatedAttestations, AttestationSignatures};
-use crate::validator::BlsPublicKey;
 
 /// The body of a block, containing payload data.
 ///

--- a/lean_client/containers/src/state.rs
+++ b/lean_client/containers/src/state.rs
@@ -107,7 +107,7 @@ impl State {
         let mut validators = List::default();
         for i in 0..num_validators.0 {
             let validator = Validator {
-                pubkey: crate::validator::BlsPublicKey::default(),
+                pubkey: crate::validator::PublicKey::default(),
                 index: Uint64(i),
             };
             validators.push(validator).expect("Failed to add validator");

--- a/lean_client/containers/src/validator.rs
+++ b/lean_client/containers/src/validator.rs
@@ -1,21 +1,24 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::ByteVector;
 use ssz_derive::Ssz;
-use typenum::U52;
+use typenum::{Unsigned, U52};
 
-/// BLS public key - 52 bytes (as defined in lean spec)
+/// Size of XMSS public keys in bytes (as defined in lean spec)
+pub type PublicKeySize = U52;
+
+/// XMSS public key (as defined in lean spec)
 #[derive(Clone, Debug, PartialEq, Eq, Ssz)]
 #[ssz(transparent)]
-pub struct BlsPublicKey(pub ByteVector<U52>);
+pub struct PublicKey(pub ByteVector<PublicKeySize>);
 
-impl Default for BlsPublicKey {
+impl Default for PublicKey {
     fn default() -> Self {
-        BlsPublicKey(ByteVector::default())
+        PublicKey(ByteVector::default())
     }
 }
 
 // Custom serde implementation
-impl Serialize for BlsPublicKey {
+impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -24,8 +27,8 @@ impl Serialize for BlsPublicKey {
         // For now, use unsafe to access the underlying bytes
         let bytes = unsafe {
             std::slice::from_raw_parts(
-                &self.0 as *const ByteVector<U52> as *const u8,
-                52
+                &self.0 as *const ByteVector<PublicKeySize> as *const u8,
+                PublicKeySize::USIZE,
             )
         };
         let hex_string = format!("0x{}", hex::encode(bytes));
@@ -33,52 +36,57 @@ impl Serialize for BlsPublicKey {
     }
 }
 
-impl<'de> Deserialize<'de> for BlsPublicKey {
+impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         let s = s.strip_prefix("0x").unwrap_or(&s);
-        
+
         let decoded = hex::decode(s).map_err(serde::de::Error::custom)?;
-        if decoded.len() != 52 {
+        if decoded.len() != PublicKeySize::USIZE {
             return Err(serde::de::Error::custom(format!(
-                "Expected 52 bytes, got {}",
+                "Expected {} bytes, got {}",
+                PublicKeySize::USIZE,
                 decoded.len()
             )));
         }
-        
+
         // Create ByteVector from decoded bytes using unsafe
         let mut byte_vec = ByteVector::default();
         unsafe {
-            let dest = &mut byte_vec as *mut ByteVector<U52> as *mut u8;
-            std::ptr::copy_nonoverlapping(decoded.as_ptr(), dest, 52);
+            let dest = &mut byte_vec as *mut ByteVector<PublicKeySize> as *mut u8;
+            std::ptr::copy_nonoverlapping(decoded.as_ptr(), dest, PublicKeySize::USIZE);
         }
-        
-        Ok(BlsPublicKey(byte_vec))
+
+        Ok(PublicKey(byte_vec))
     }
 }
 
-impl BlsPublicKey {
+impl PublicKey {
     pub fn from_hex(s: &str) -> Result<Self, String> {
         let s = s.strip_prefix("0x").unwrap_or(s);
         let decoded = hex::decode(s).map_err(|e| e.to_string())?;
-        if decoded.len() != 52 {
-            return Err(format!("Expected 52 bytes, got {}", decoded.len()));
+        if decoded.len() != PublicKeySize::USIZE {
+            return Err(format!(
+                "Expected {} bytes, got {}",
+                PublicKeySize::USIZE,
+                decoded.len()
+            ));
         }
         let mut byte_vec = ByteVector::default();
         unsafe {
-            let dest = &mut byte_vec as *mut ByteVector<U52> as *mut u8;
-            std::ptr::copy_nonoverlapping(decoded.as_ptr(), dest, 52);
+            let dest = &mut byte_vec as *mut ByteVector<PublicKeySize> as *mut u8;
+            std::ptr::copy_nonoverlapping(decoded.as_ptr(), dest, PublicKeySize::USIZE);
         }
-        Ok(BlsPublicKey(byte_vec))
+        Ok(PublicKey(byte_vec))
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, Ssz, Serialize, Deserialize)]
 pub struct Validator {
-    pub pubkey: BlsPublicKey,
+    pub pubkey: PublicKey,
     #[serde(default)]
     pub index: crate::Uint64,
 }

--- a/lean_client/containers/src/validator.rs
+++ b/lean_client/containers/src/validator.rs
@@ -4,7 +4,7 @@ use ssz_derive::Ssz;
 use typenum::{Unsigned, U52};
 
 /// Size of XMSS public keys in bytes (as defined in lean spec)
-pub type PublicKeySize = U52;
+type PublicKeySize = U52;
 
 /// XMSS public key (as defined in lean spec)
 #[derive(Clone, Debug, PartialEq, Eq, Ssz)]

--- a/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
+++ b/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
@@ -384,7 +384,7 @@ fn initialize_state_from_test(test_state: &TestAnchorState) -> State {
 
     let mut validators = List::default();
     for test_validator in &test_state.validators.data {
-        let pubkey = containers::validator::BlsPublicKey::from_hex(&test_validator.pubkey)
+        let pubkey = containers::validator::PublicKey::from_hex(&test_validator.pubkey)
             .expect("Failed to parse validator pubkey");
         let validator = containers::validator::Validator {
             pubkey,

--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -164,7 +164,7 @@ async fn main() {
             .iter()
             .enumerate()
             .map(|(i, v_str)| {
-                let pubkey = containers::validator::BlsPublicKey::from_hex(v_str)
+                let pubkey = containers::validator::PublicKey::from_hex(v_str)
                     .expect("Invalid genesis validator pubkey");
                 containers::validator::Validator {
                     pubkey,
@@ -178,7 +178,7 @@ async fn main() {
         let num_validators = 3;
         let validators = (0..num_validators)
             .map(|i| containers::validator::Validator {
-                pubkey: containers::validator::BlsPublicKey::default(),
+                pubkey: containers::validator::PublicKey::default(),
                 index: Uint64(i as u64),
             })
             .collect();

--- a/lean_client/validator/src/keys.rs
+++ b/lean_client/validator/src/keys.rs
@@ -93,7 +93,7 @@ impl KeyManager {
                 ).into());
             }
 
-            // Convert to ByteVector<U3112> using unsafe pointer copy (same pattern as BlsPublicKey)
+            // Convert to ByteVector<U3112> using unsafe pointer copy (same pattern as PublicKey)
             let mut byte_vec: ByteVector<U3112> = ByteVector::default();
             unsafe {
                 let dest = &mut byte_vec as *mut ByteVector<U3112> as *mut u8;


### PR DESCRIPTION
XMSS seems  to be used (https://github.com/grandinetech/lean/blob/devnet-2/lean_client/validator/src/keys.rs). An incorrect name was used for the struct.
- Renamed BlsPublicKey to PublicKey
- Added constant for key size