### PR TITLE
Include additional metadata in docker image

### DIFF
--- a/lean_client/Dockerfile
+++ b/lean_client/Dockerfile
@@ -1,5 +1,16 @@
 FROM ubuntu:22.04
 
+ARG COMMIT_SHA
+ARG BUILD_DATE
+
+LABEL org.opencontainers.image.title="grandine"
+LABEL org.opencontainers.image.description="High performance Ethereum lean client"
+LABEL org.opencontainers.image.authors="Grandine <info@grandine.io>"
+LABEL org.opencontainers.image.source=https://github.com/grandinetech/lean
+LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.revision=$COMMIT_SHA
+LABEL org.opencontainers.image.created=$BUILD_DATE
+
 ARG TARGETARCH
 
 COPY ./bin/$TARGETARCH/lean_client /usr/local/bin/lean_client

--- a/lean_client/Makefile
+++ b/lean_client/Makefile
@@ -30,6 +30,8 @@ aarch64-unknown-linux-gnu: ./target/aarch64-unknown-linux-gnu/release/lean_clien
 
 DOCKER_REPO ?= sifrai/lean
 DOCKER_TAG ?= unstable
+COMMIT_SHA := $(shell git rev-parse HEAD)
+BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 .PHONY: release
 release: docker
@@ -43,6 +45,8 @@ docker: ./target/x86_64-unknown-linux-gnu/release/lean_client ./target/aarch64-u
 	docker buildx build \
 		--file Dockerfile \
 		--platform linux/amd64,linux/arm64 \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		--tag $(DOCKER_REPO):$(DOCKER_TAG) \
 		--push \
 		.


### PR DESCRIPTION
Added labels to lean image with several metadata fields, including build commit hash, as requested in lean devnet telegram. Labels are added according to [opencontainers annotations standard].

[opencontainers annotations standard]: https://github.com/opencontainers/image-spec/blob/main/annotations.md