### PR TITLE
Fix devnet2 finalization issues

### DIFF
--- a/lean_client/Cargo.lock
+++ b/lean_client/Cargo.lock
@@ -1076,6 +1076,8 @@ name = "containers"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitvec",
+ "bls",
  "env-config",
  "hex",
  "metrics",
@@ -1866,6 +1868,7 @@ name = "fork_choice"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bls",
  "containers",
  "env-config",
  "metrics",
@@ -6522,6 +6525,7 @@ dependencies = [
  "serde_yaml",
  "ssz",
  "tracing",
+ "try_from_iterator",
  "typenum",
  "xmss",
  "zeroize",

--- a/lean_client/Cargo.toml
+++ b/lean_client/Cargo.toml
@@ -233,6 +233,7 @@ xmss = { path = "./xmss" }
 anyhow = "1.0.100"
 async-trait = "0.1"
 axum = "0.8.8"
+bitvec = "1.0.1"
 bls = { git = "https://github.com/grandinetech/grandine", package = "bls", features = ["blst"], rev = "64afdee3c6be79fceffb66933dcb69a943f3f1ae" }
 clap = { version = "4", features = ["derive"] }
 derive_more = "2.1.1"

--- a/lean_client/containers/Cargo.toml
+++ b/lean_client/containers/Cargo.toml
@@ -4,6 +4,8 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bitvec = { workspace = true }
+bls = { workspace = true }
 env-config = { workspace = true }
 hex = { workspace = true }
 metrics = { workspace = true }

--- a/lean_client/containers/src/attestation.rs
+++ b/lean_client/containers/src/attestation.rs
@@ -61,6 +61,7 @@ impl AggregatedSignatureProof {
 /// Bitlist representing validator participation in an attestation.
 /// Limit is VALIDATOR_REGISTRY_LIMIT (4096).
 #[derive(Clone, Debug, Ssz, Serialize, Deserialize)]
+#[ssz(transparent)]
 pub struct AggregationBits(
     #[serde(with = "crate::serde_helpers::bitlist")] pub BitList<ValidatorRegistryLimit>,
 );

--- a/lean_client/containers/src/lib.rs
+++ b/lean_client/containers/src/lib.rs
@@ -10,8 +10,8 @@ mod validator;
 
 pub use attestation::{
     AggregatedAttestation, AggregatedSignatureProof, AggregatedSignatures, AggregationBits,
-    Attestation, AttestationData, Attestations, SignatureKey, SignedAggregatedAttestation,
-    SignedAttestation,
+    Attestation, AttestationData, AttestationSignatures, Attestations, SignatureKey,
+    SignedAggregatedAttestation, SignedAttestation,
 };
 pub use block::{
     Block, BlockBody, BlockHeader, BlockSignatures, BlockWithAttestation, SignedBlock,

--- a/lean_client/containers/src/slot.rs
+++ b/lean_client/containers/src/slot.rs
@@ -17,6 +17,10 @@ impl Ord for Slot {
 }
 
 impl Slot {
+    pub fn justified_index_after(self, finalized_slot: Slot) -> Option<u64> {
+        self.0.checked_sub(finalized_slot.0 + 1)
+    }
+
     /// Checks if this slot is a valid candidate for justification after a given finalized slot.
     ///
     /// According to the 3SF-mini specification, a slot is justifiable if its

--- a/lean_client/containers/tests/unit_tests/state_basic.rs
+++ b/lean_client/containers/tests/unit_tests/state_basic.rs
@@ -29,15 +29,9 @@ fn test_generate_genesis() {
 
     // Check that collections are empty by trying to get the first element
     assert!(state.historical_block_hashes.get(0).is_err());
-    assert!(state.justified_slots.get(0).is_none());
+    assert!(state.justified_slots.0.get(0).is_none());
     assert!(state.justifications_roots.get(0).is_err());
     assert!(state.justifications_validators.get(0).is_none());
-}
-
-#[test]
-fn test_proposer_round_robin() {
-    let state = State::generate_genesis(0, 4);
-    assert!(state.is_proposer(0));
 }
 
 #[test]

--- a/lean_client/containers/tests/unit_tests/state_process.rs
+++ b/lean_client/containers/tests/unit_tests/state_process.rs
@@ -15,27 +15,6 @@ pub fn genesis_state() -> State {
 }
 
 #[test]
-fn test_process_slot() {
-    let genesis_state = genesis_state();
-
-    assert_eq!(genesis_state.latest_block_header.state_root, H256::zero());
-
-    let state_after_slot = genesis_state.process_slot();
-    let expected_root = genesis_state.hash_tree_root();
-
-    assert_eq!(
-        state_after_slot.latest_block_header.state_root,
-        expected_root
-    );
-
-    let state_after_second_slot = state_after_slot.process_slot();
-    assert_eq!(
-        state_after_second_slot.latest_block_header.state_root,
-        expected_root
-    );
-}
-
-#[test]
 fn test_process_slots() {
     let genesis_state = genesis_state();
     let target_slot = Slot(5);
@@ -79,6 +58,7 @@ fn test_process_block_header_valid() {
     // justified_slots should be empty or all false.
     let justified_slot_1_relative = new_state
         .justified_slots
+        .0
         .get(0) // relative index 0 = slot 1
         .map(|b| *b)
         .unwrap_or(false);
@@ -89,9 +69,9 @@ fn test_process_block_header_valid() {
 }
 
 #[rstest]
-#[case(2, 1, None, "block slot mismatch")]
-#[case(1, 2, None, "incorrect block proposer")]
-#[case(1, 1, Some(H256::from_slice(&[0xde; 32])), "block parent root mismatch")]
+#[case(2, 1, None, "Block slot mismatch")]
+#[case(1, 2, None, "Incorrect block proposer")]
+#[case(1, 1, Some(H256::from_slice(&[0xde; 32])), "Block parent root mismatch")]
 fn test_process_block_header_invalid(
     #[case] bad_slot: u64,
     #[case] bad_proposer: u64,

--- a/lean_client/containers/tests/unit_tests/state_transition.rs
+++ b/lean_client/containers/tests/unit_tests/state_transition.rs
@@ -35,7 +35,9 @@ fn test_state_transition_full() {
     // Use process_block_header + process_operations to avoid state root validation during setup
     let state_after_header = state_at_slot_1.process_block_header(&block).unwrap();
 
-    let expected_state = state_after_header.process_attestations(&block.body.attestations);
+    let expected_state = state_after_header
+        .process_attestations(&block.body.attestations)
+        .unwrap();
 
     let block_with_correct_root = Block {
         state_root: expected_state.hash_tree_root(),
@@ -72,7 +74,9 @@ fn test_state_transition_invalid_signatures() {
     // Use process_block_header + process_operations to avoid state root validation during setup
     let state_after_header = state_at_slot_1.process_block_header(&block).unwrap();
 
-    let expected_state = state_after_header.process_attestations(&block.body.attestations);
+    let expected_state = state_after_header
+        .process_attestations(&block.body.attestations)
+        .unwrap();
 
     let block_with_correct_root = Block {
         state_root: expected_state.hash_tree_root(),
@@ -131,7 +135,9 @@ fn test_state_transition_devnet2() {
     // Process the block header and attestations
     let state_after_header = state_at_slot_1.process_block_header(&block).unwrap();
 
-    let expected_state = state_after_header.process_attestations(&block.body.attestations);
+    let expected_state = state_after_header
+        .process_attestations(&block.body.attestations)
+        .unwrap();
 
     // Ensure the state root matches the expected state
     let block_with_correct_root = Block {

--- a/lean_client/fork_choice/Cargo.toml
+++ b/lean_client/fork_choice/Cargo.toml
@@ -4,6 +4,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bls = { workspace = true }
 containers = { workspace = true }
 env-config = { workspace = true }
 metrics = { workspace = true }

--- a/lean_client/fork_choice/src/handlers.rs
+++ b/lean_client/fork_choice/src/handlers.rs
@@ -308,19 +308,19 @@ fn process_block_internal(
         attestations_in_block = attestations_count,
         parent_justified_slot = state.latest_justified.slot.0,
         parent_finalized_slot = state.latest_finalized.slot.0,
-        justified_slots_len = state.justified_slots.len(),
+        justified_slots_len = state.justified_slots.0.len(),
         "Processing block - parent state info"
     );
 
     // Execute state transition to get post-state
-    let new_state = state.state_transition_with_validation(signed_block.clone(), true, true)?;
+    let new_state = state.state_transition(signed_block.clone(), true)?;
 
     // Debug: Log new state checkpoints after transition
     tracing::debug!(
         block_slot = block.slot.0,
         new_justified_slot = new_state.latest_justified.slot.0,
         new_finalized_slot = new_state.latest_finalized.slot.0,
-        new_justified_slots_len = new_state.justified_slots.len(),
+        new_justified_slots_len = new_state.justified_slots.0.len(),
         "Block processed - new state info"
     );
 

--- a/lean_client/fork_choice/src/lib.rs
+++ b/lean_client/fork_choice/src/lib.rs
@@ -1,2 +1,8 @@
 pub mod handlers;
 pub mod store;
+
+// dirty hack to avoid issues compiling grandine dependencies. by default, bls
+// crate has no features enabled, and thus compilation fails (as exactly one
+// backend must be enabled). So we include bls crate with one feature enabled,
+// to make everything work.
+use bls as _;

--- a/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
+++ b/lean_client/fork_choice/tests/fork_choice_test_vectors.rs
@@ -10,7 +10,7 @@ use fork_choice::{
 };
 
 use serde::Deserialize;
-use ssz::{H256, SszHash};
+use ssz::{BitList, H256, SszHash};
 use std::{collections::HashMap, fs::File};
 use std::{panic::AssertUnwindSafe, path::Path};
 use test_generator::test_resources;
@@ -60,10 +60,11 @@ impl Into<State> for TestAnchorState {
                 .expect("within limit");
         }
 
-        let mut justified_slots = JustifiedSlots::new(false, self.justified_slots.data.len());
+        let mut justified_slots =
+            JustifiedSlots(BitList::new(false, self.justified_slots.data.len()));
         for (i, &val) in self.justified_slots.data.iter().enumerate() {
             if val {
-                justified_slots.set(i, true);
+                justified_slots.0.set(i, true);
             }
         }
 

--- a/lean_client/fork_choice/tests/unit_tests/fork_choice.rs
+++ b/lean_client/fork_choice/tests/unit_tests/fork_choice.rs
@@ -1,6 +1,6 @@
 use super::common::create_test_store;
 use containers::{Block, BlockBody, Slot};
-use fork_choice::store::{get_proposal_head, get_vote_target};
+use fork_choice::store::get_proposal_head;
 use ssz::{H256, SszHash};
 
 #[test]
@@ -49,7 +49,7 @@ fn test_get_vote_target_chain() {
     // With head at 10 and safe_target at 0:
     // 1. Walk back 3 slots from head -> 7
     // 2. Walk back until justifiable from finalized (0) -> 6
-    let target = get_vote_target(&store);
+    let target = store.get_attestation_target();
 
     assert_eq!(target.slot, Slot(6));
 }

--- a/lean_client/networking/src/gossipsub/config.rs
+++ b/lean_client/networking/src/gossipsub/config.rs
@@ -19,6 +19,9 @@ impl GossipsubConfig {
         let seen_ttl_secs = seconds_per_slot * justification_lookback_slots * 2;
 
         let config = ConfigBuilder::default()
+            // for now, increased to 16 mb. in the future, should be handled in config
+            // TODO(p2p): compute transmit size
+            .max_transmit_size(16 * 1024 * 1024)
             // leanSpec: heartbeat_interval_secs = 0.7
             .heartbeat_interval(Duration::from_millis(700))
             // leanSpec: fanout_ttl_secs = 60

--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -18,10 +18,10 @@ use networking::gossipsub::topic::get_topics;
 use networking::network::{NetworkService, NetworkServiceConfig};
 use networking::types::{ChainMessage, OutboundP2pRequest};
 use ssz::{PersistentList, SszHash};
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::{io::IsTerminal, net::IpAddr};
 use tokio::{
     sync::mpsc,
     task,
@@ -141,6 +141,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
+        .with_ansi(std::io::stdout().is_terminal())
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(LevelFilter::INFO.into())

--- a/lean_client/validator/Cargo.toml
+++ b/lean_client/validator/Cargo.toml
@@ -12,6 +12,7 @@ metrics = { workspace = true }
 serde_yaml = { workspace = true }
 ssz = { workspace = true }
 tracing = { workspace = true }
+try_from_iterator = { workspace = true }
 typenum = { workspace = true }
 xmss = { workspace = true }
 zeroize = { workspace = true }

--- a/lean_client/xmss/src/aggregated_signature.rs
+++ b/lean_client/xmss/src/aggregated_signature.rs
@@ -11,7 +11,7 @@ use lean_multisig::{
 };
 use metrics::{METRICS, stop_and_discard};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
-use ssz::{ByteList, Ssz};
+use ssz::{ByteList, Ssz, SszRead};
 use typenum::U1048576;
 
 /// Max size currently is 1MiB by spec.
@@ -27,6 +27,7 @@ type AggregatedSignatureSizeLimit = U1048576;
 /// todo(xmss): deriving Ssz not particularly good there, as this won't validate
 /// if it actually has valid proof structure, so `.as_lean()` method may panic.
 #[derive(Debug, Clone, Ssz)]
+#[ssz(transparent)]
 pub struct AggregatedSignature(ByteList<AggregatedSignatureSizeLimit>);
 
 fn setup_prover() {

--- a/lean_client/xmss/src/signature.rs
+++ b/lean_client/xmss/src/signature.rs
@@ -21,7 +21,8 @@ type SignatureSize = U3112;
 type LeanSigSignature = <SIGTopLevelTargetSumLifetime32Dim64Base8 as SignatureScheme>::Signature;
 
 // todo(xmss): default implementation doesn't make sense here, and is needed only for tests
-#[derive(Ssz, Clone, Default)]
+#[derive(Clone, Default, Ssz)]
+#[ssz(transparent)]
 pub struct Signature(ByteVector<SignatureSize>);
 
 impl Signature {


### PR DESCRIPTION
Fixed few finalization issues, encountered in devnet-2:
* Invalid proposer signature - this was due to invalid signature SSZ representation - previously it was a byte list inside container, now it is just a byte list.
* Unknown block errors - p2p limits weren't configured properly, and with addition of aggregated signatures (which can be up to 1mb), messages with blocks weren't received.
* Finalization issues - validator public key was in invalid format, similar to proposer signature error.

Overall this not only fixes all finalization issues related to devnet-2, but also state transition code was refactored a bit to be more similar to spec.