### PR TITLE
fix: retain proposer attestation data

### DIFF
--- a/lean_client/fork_choice/src/handlers.rs
+++ b/lean_client/fork_choice/src/handlers.rs
@@ -515,6 +515,9 @@ fn process_block_internal(
     store
         .gossip_signatures
         .insert(proposer_sig_key, signed_block.signature.proposer_signature);
+    store
+        .attestation_data_by_root
+        .insert(proposer_data_root, proposer_attestation.data.clone());
 
     // Process proposer attestation as if received via gossip (is_from_block=false)
     // This ensures it goes to "new" attestations and doesn't immediately affect fork choice


### PR DESCRIPTION
Fixes log warning: 
`WARN validator: Could not find attestation data for aggregation group data_root=...`
found in lean/lean_client/validator/src/lib.rs maybe_aggregate

This log comes up when the client is an aggregator and propagates for every proposer_attestation_root in every slot where the client is an aggregator. For current devnet-3 testing in lean-quickstart the log continues to grow per slot until by slot 1000 the log message for slot 1000 is ~700 lines long and so on. After the fix all slot logs average around ~50 lines improving readability

The fix is to make the on_block() behavior in line with leanspec where both the proposer_attestation_root and actual proposer_attestation data are stored as opposed to just storing the proposer_attestation_root

https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/forkchoice/store.py
line 613-616:
`sig = signed_block_with_attestation.signature.proposer_signature
                new_gossip_sigs.setdefault(proposer_attestation.data, set()).add(
                    GossipSignatureEntry(proposer_attestation.validator_id, sig)
                )`
                
