### PR TITLE
fix: main loop deadlock fix

### DIFF
--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -865,7 +865,7 @@ async fn main() -> Result<()> {
                                 }
                                 continue;
                             }
-                            
+
                             let result = {on_block(&mut *store.write(), signed_block_with_attestation.clone())};
                             match result {
                                 Ok(()) => {

--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -708,7 +708,8 @@ async fn main() -> Result<()> {
                                             "Our turn to propose block!"
                                         );
 
-                                        match vs.build_block_proposal(&mut *store.write(), Slot(current_slot), proposer_idx) {
+                                        let result = {vs.build_block_proposal(&mut *store.write(), Slot(current_slot), proposer_idx)};
+                                        match result {
                                             Ok(signed_block) => {
                                                 let block_root = signed_block.message.block.hash_tree_root();
                                                 info!(
@@ -864,8 +865,9 @@ async fn main() -> Result<()> {
                                 }
                                 continue;
                             }
-
-                            match on_block(&mut *store.write(), signed_block_with_attestation.clone()) {
+                            
+                            let result = {on_block(&mut *store.write(), signed_block_with_attestation.clone())};
+                            match result {
                                 Ok(()) => {
                                     info!("Block processed successfully");
 


### PR DESCRIPTION
There were two instances that were recently added in the main loop where a store write lock wasn't properly freed in a match enclosure, causing the client to deadlock at the first run of the loop, and then almost immediately after once the first deadlock was fixed. I've fixed it by adding the offending locks to a result enclosure so the locks are freed before the respective match enclosures.