### PR TITLE
Optimize build pipeline

### DIFF
--- a/lean_client/Dockerfile
+++ b/lean_client/Dockerfile
@@ -1,29 +1,3 @@
-# ==============================================================================
-# Stage 1: Builder
-# ==============================================================================
-FROM rustlang/rust:nightly-bookworm AS builder
-
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    pkg-config \
-    libssl-dev \
-    libclang-dev \
-    cmake \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
-
-# Copy source code
-COPY . .
-
-# Build release binary
-RUN cargo build --release
-
-# ==============================================================================
-# Stage 2: Runtime
-# ==============================================================================
 FROM ubuntu:22.04
 
 ARG COMMIT_SHA
@@ -39,13 +13,8 @@ LABEL org.opencontainers.image.revision=$COMMIT_SHA
 LABEL org.opencontainers.image.ref.name=$GIT_BRANCH
 LABEL org.opencontainers.image.created=$BUILD_DATE
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    libssl3 \
-    && rm -rf /var/lib/apt/lists/*
+ARG TARGETARCH
 
-# Copy binary from builder stage
-COPY --from=builder /app/target/release/lean_client /usr/local/bin/lean_client
+COPY ./bin/$TARGETARCH/lean_client /usr/local/bin/lean_client
 
 ENTRYPOINT ["lean_client"]


### PR DESCRIPTION
Commit [`e11f365`] introduced build time regression - the dockerfile was modified to include two stages - one for build, another one for running. However, our compilation pipeline uses cross to build binaries, then copying it to final image. These dockerfile changes, combined with existing building pipeline, caused to build the same binary four times: two times for each supported platform.

This PR reverts changes back to original Dockerfile build process, speeding up release pipeline (from ~1.5h to ~10 minutes).

[`e11f365`]: https://github.com/grandinetech/lean/commit/e11f365f1d54f2d42b6054e2ba38d3ce7615c2ff