### PR TITLE
Split formatting/building/testing CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: CI
 on: 
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: Check formatting

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,13 +3,22 @@ on:
   - pull_request
 
 jobs:
-  ci:
+  format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check formatting
+        run: make check-format
+
+  build:
+    name: Build client
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Enable long paths (Windows)
         if: runner.os == 'Windows'
@@ -19,11 +28,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Check formatting
-        run: make check-format
-
       - name: Build client
         run: make build
+
+  test:
+    name: Run tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Enable long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+        shell: bash
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
       - name: Run tests
         run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build client
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Enable long paths (Windows)
@@ -39,7 +39,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Enable long paths (Windows)

--- a/lean_client/metrics/src/metrics.rs
+++ b/lean_client/metrics/src/metrics.rs
@@ -453,7 +453,10 @@ impl Metrics {
 
             // Node Status
             lean_node_sync_status: GaugeVec::new(
-                opts!("lean_node_sync_status", "Node sync status (idle/syncing/synced)"),
+                opts!(
+                    "lean_node_sync_status",
+                    "Node sync status (idle/syncing/synced)"
+                ),
                 &["status"],
             )?,
 
@@ -462,8 +465,14 @@ impl Metrics {
                 "lean_gossip_block_size_bytes",
                 "Bytes size of a gossip block message",
                 vec![
-                    10_000.0, 50_000.0, 100_000.0, 250_000.0, 500_000.0,
-                    1_000_000.0, 2_000_000.0, 5_000_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    250_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    2_000_000.0,
+                    5_000_000.0,
                 ]
             ))?,
             lean_gossip_attestation_size_bytes: Histogram::with_opts(histogram_opts!(
@@ -475,8 +484,14 @@ impl Metrics {
                 "lean_gossip_aggregation_size_bytes",
                 "Bytes size of a gossip aggregated attestation message",
                 vec![
-                    1_024.0, 4_096.0, 16_384.0, 65_536.0, 131_072.0,
-                    262_144.0, 524_288.0, 1_048_576.0,
+                    1_024.0,
+                    4_096.0,
+                    16_384.0,
+                    65_536.0,
+                    131_072.0,
+                    262_144.0,
+                    524_288.0,
+                    1_048_576.0,
                 ]
             ))?,
         })
@@ -594,23 +609,20 @@ impl Metrics {
         // Block Production Metrics
         default_registry.register(Box::new(self.lean_block_building_time_seconds.clone()))?;
         default_registry.register(Box::new(
-            self.lean_block_building_payload_aggregation_time_seconds.clone(),
+            self.lean_block_building_payload_aggregation_time_seconds
+                .clone(),
         ))?;
         default_registry.register(Box::new(self.lean_block_aggregated_payloads.clone()))?;
-        default_registry
-            .register(Box::new(self.lean_block_building_success_total.clone()))?;
-        default_registry
-            .register(Box::new(self.lean_block_building_failures_total.clone()))?;
+        default_registry.register(Box::new(self.lean_block_building_success_total.clone()))?;
+        default_registry.register(Box::new(self.lean_block_building_failures_total.clone()))?;
 
         // Node Status
         default_registry.register(Box::new(self.lean_node_sync_status.clone()))?;
 
         // Gossip Size Metrics
         default_registry.register(Box::new(self.lean_gossip_block_size_bytes.clone()))?;
-        default_registry
-            .register(Box::new(self.lean_gossip_attestation_size_bytes.clone()))?;
-        default_registry
-            .register(Box::new(self.lean_gossip_aggregation_size_bytes.clone()))?;
+        default_registry.register(Box::new(self.lean_gossip_attestation_size_bytes.clone()))?;
+        default_registry.register(Box::new(self.lean_gossip_aggregation_size_bytes.clone()))?;
 
         Ok(())
     }

--- a/lean_client/networking/src/network/service.rs
+++ b/lean_client/networking/src/network/service.rs
@@ -568,7 +568,9 @@ where
                 let data_len = message.data.len();
                 match GossipsubMessage::decode(&message.topic, &message.data) {
                     Ok(GossipsubMessage::Block(signed_block)) => {
-                        METRICS.get().map(|m| m.lean_gossip_block_size_bytes.observe(data_len as f64));
+                        METRICS
+                            .get()
+                            .map(|m| m.lean_gossip_block_size_bytes.observe(data_len as f64));
                         info!(block_root = %signed_block.block.hash_tree_root(), "received block via gossip");
 
                         let slot = signed_block.block.slot.0;
@@ -591,7 +593,10 @@ where
                         subnet_id,
                         attestation,
                     }) => {
-                        METRICS.get().map(|m| m.lean_gossip_attestation_size_bytes.observe(data_len as f64));
+                        METRICS.get().map(|m| {
+                            m.lean_gossip_attestation_size_bytes
+                                .observe(data_len as f64)
+                        });
                         info!(
                             validator = %attestation.validator_id,
                             slot = %attestation.message.slot.0,
@@ -615,7 +620,10 @@ where
                         }
                     }
                     Ok(GossipsubMessage::Aggregation(signed_aggregated_attestation)) => {
-                        METRICS.get().map(|m| m.lean_gossip_aggregation_size_bytes.observe(data_len as f64));
+                        METRICS.get().map(|m| {
+                            m.lean_gossip_aggregation_size_bytes
+                                .observe(data_len as f64)
+                        });
                         info!(
                             slot = %signed_aggregated_attestation.data.slot.0,
                             "received aggregated attestation via gossip"


### PR DESCRIPTION
This PR splits formatting, building and testing into separate CI jobs. This would allow seeing issues more easily, making results more clear.