### PR TITLE
bump multisig port spec fixes add instrumentation

### DIFF
--- a/lean_client/Cargo.lock
+++ b/lean_client/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1724,7 +1724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2795,6 +2795,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,9 +3017,10 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_vm",
  "pest",
  "pest_derive",
@@ -3013,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3022,6 +3042,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand 0.10.1",
+ "serde",
  "sub_protocols",
  "tracing",
  "utils",
@@ -3030,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3086,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -3702,7 +3723,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -3711,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -3719,12 +3740,13 @@ dependencies = [
  "mt-utils",
  "rayon",
  "serde",
+ "tracing",
 ]
 
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -3739,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -3755,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -3763,12 +3785,13 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "system-info",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -3781,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -3791,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "serde",
 ]
@@ -3799,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -3811,6 +3834,7 @@ dependencies = [
  "mt-utils",
  "rand 0.10.1",
  "rayon",
+ "system-info",
  "tracing",
 ]
 
@@ -3987,6 +4011,7 @@ dependencies = [
  "enr",
  "env-config",
  "futures",
+ "git-version",
  "hex",
  "k256",
  "libp2p",
@@ -4049,7 +4074,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4098,6 +4123,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,7 +4182,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -4147,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4160,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4174,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -4189,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -4204,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4218,12 +4268,12 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -4235,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -4258,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4269,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4281,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4292,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#e0bc50c6f29bca1be2eee92d215e1eb4431c6d50"
 dependencies = [
  "serde",
  "transpose",
@@ -4866,7 +4916,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5056,14 +5106,17 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_compiler",
  "lean_prover",
  "lean_vm",
  "leansig_wrapper",
  "lz4_flex",
+ "objc2",
+ "objc2-foundation",
  "postcard",
  "rand 0.10.1",
  "serde",
@@ -5071,6 +5124,7 @@ dependencies = [
  "sub_protocols",
  "tracing",
  "utils",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -5364,7 +5418,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5795,7 +5849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5964,7 +6018,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "lean_vm",
@@ -6065,6 +6119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-info"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "rayon",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6086,7 +6149,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6674,7 +6737,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "tracing",
@@ -7051,16 +7114,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7078,31 +7132,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -7121,22 +7158,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7145,22 +7170,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7169,22 +7182,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7193,22 +7194,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7371,6 +7360,7 @@ name = "xmss"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bls",
  "derive_more",
  "ethereum-types",
  "ethereum_ssz",
@@ -7565,6 +7555,15 @@ dependencies = [
  "rand 0.8.5",
  "static_assertions",
  "tiny-keccak",
+]
+
+[[package]]
+name = "zk-alloc"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "system-info",
 ]
 
 [[package]]

--- a/lean_client/Cargo.toml
+++ b/lean_client/Cargo.toml
@@ -251,9 +251,9 @@ indexmap = "2"
 http-body-util = "0.1"
 http_api_utils = { git = "https://github.com/grandinetech/grandine", rev = "64afdee3c6be79fceffb66933dcb69a943f3f1ae" }
 k256 = "0.13"
-rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
+rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
 leansig = { git = "https://github.com/leanEthereum/leanSig" }
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
 libp2p = { version = "0.56.0", default-features = false, features = [
     'dns',
     'gossipsub',

--- a/lean_client/containers/src/state.rs
+++ b/lean_client/containers/src/state.rs
@@ -567,14 +567,17 @@ impl State {
 
             if 3 * count >= 2 * self.validators.len_u64() {
                 info!("justifying slot {target:?}");
-                latest_justified = target.clone();
+                if target.slot > latest_justified.slot {
+                    latest_justified = target.clone();
+                }
                 justified_slots =
                     justified_slots.with_justified(finalized_slot, target.slot, true)?;
 
                 justifications.remove(&target.root);
 
-                if !(source.slot.0 + 1..target.slot.0)
-                    .any(|slot| Slot(slot).is_justifiable_after(finalized_slot))
+                if source.slot > finalized_slot
+                    && !(source.slot.0 + 1..target.slot.0)
+                        .any(|slot| Slot(slot).is_justifiable_after(finalized_slot))
                 {
                     info!("finalizing {source:?}");
                     let old_finalized_slot = finalized_slot;
@@ -971,4 +974,101 @@ impl State {
 
 fn is_proposer_for(validator_index: u64, slot: Slot, num_validators: u64) -> bool {
     slot.0 % num_validators == validator_index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AggregatedAttestation, AggregationBits, AttestationData, Block, BlockBody, Checkpoint,
+    };
+    use ssz::SszHash;
+
+    #[test]
+    fn test_same_block_multi_target_attestations_advance_to_highest_slot() -> Result<()> {
+        let mut state = State::generate_genesis(0, 4);
+
+        let mut source_root = H256::zero();
+        let mut block_4_root = H256::zero();
+        let mut block_6_root = H256::zero();
+
+        for slot in 1u64..=9 {
+            state = state.process_slots(Slot(slot))?;
+            let parent_root = state.latest_block_header.hash_tree_root();
+
+            match slot {
+                1 => source_root = parent_root,
+                5 => block_4_root = parent_root,
+                7 => block_6_root = parent_root,
+                _ => {}
+            }
+
+            let block = Block {
+                slot: Slot(slot),
+                proposer_index: slot % 4,
+                parent_root,
+                state_root: H256::zero(),
+                body: BlockBody {
+                    attestations: PersistentList::default(),
+                },
+            };
+            state = state.process_block(&block)?;
+        }
+
+        state = state.process_slots(Slot(10))?;
+        let block_9_root = state.latest_block_header.hash_tree_root();
+
+        let bits = AggregationBits::from_validator_indices(&[0, 1, 2]);
+
+        let make = |target_slot: u64, target_root: H256| AggregatedAttestation {
+            aggregation_bits: bits.clone(),
+            data: AttestationData {
+                slot: Slot(10),
+                head: Checkpoint {
+                    slot: Slot(9),
+                    root: block_9_root,
+                },
+                target: Checkpoint {
+                    slot: Slot(target_slot),
+                    root: target_root,
+                },
+                source: Checkpoint {
+                    slot: Slot(0),
+                    root: source_root,
+                },
+            },
+        };
+
+        let mut attestations: AggregatedAttestations = PersistentList::default();
+        attestations.push(make(4, block_4_root))?;
+        attestations.push(make(9, block_9_root))?;
+        attestations.push(make(6, block_6_root))?;
+
+        let block_10 = Block {
+            slot: Slot(10),
+            proposer_index: 10 % 4,
+            parent_root: block_9_root,
+            state_root: H256::zero(),
+            body: BlockBody { attestations },
+        };
+
+        state = state.process_block(&block_10)?;
+
+        assert_eq!(state.latest_justified.slot, Slot(9));
+        assert_eq!(state.latest_finalized.slot, Slot(0));
+        assert!(
+            state.justified_slots.0.get(3).map(|v| *v).unwrap_or(false),
+            "slot 4 (index 3) should be justified"
+        );
+        assert!(
+            state.justified_slots.0.get(5).map(|v| *v).unwrap_or(false),
+            "slot 6 (index 5) should be justified"
+        );
+        assert!(
+            state.justified_slots.0.get(8).map(|v| *v).unwrap_or(false),
+            "slot 9 (index 8) should be justified"
+        );
+
+        Ok(())
+    }
 }

--- a/lean_client/metrics/src/metrics.rs
+++ b/lean_client/metrics/src/metrics.rs
@@ -133,6 +133,9 @@ pub struct Metrics {
     /// Number of gossip signatures in fork-choice store
     pub lean_gossip_signatures: IntGauge,
 
+    /// Inbound gossipsub messages that failed snappy decompression, by topic kind
+    pub lean_gossip_decompress_failures_total: IntCounterVec,
+
     /// Number of new aggregated payload items
     pub lean_latest_new_aggregated_payloads: IntGauge,
 
@@ -452,6 +455,13 @@ impl Metrics {
             lean_gossip_signatures: IntGauge::new(
                 "lean_gossip_signatures",
                 "Number of gossip signatures in fork-choice store",
+            )?,
+            lean_gossip_decompress_failures_total: IntCounterVec::new(
+                opts!(
+                    "lean_gossip_decompress_failures_total",
+                    "Inbound gossipsub messages that failed snappy decompression, by topic kind",
+                ),
+                &["topic_kind"],
             )?,
             lean_latest_new_aggregated_payloads: IntGauge::new(
                 "lean_latest_new_aggregated_payloads",
@@ -785,6 +795,7 @@ impl Metrics {
 
         // Additional Fork-Choice Metrics
         default_registry.register(Box::new(self.lean_gossip_signatures.clone()))?;
+        default_registry.register(Box::new(self.lean_gossip_decompress_failures_total.clone()))?;
         default_registry.register(Box::new(self.lean_latest_new_aggregated_payloads.clone()))?;
         default_registry.register(Box::new(self.lean_latest_known_aggregated_payloads.clone()))?;
         default_registry.register(Box::new(

--- a/lean_client/networking/Cargo.toml
+++ b/lean_client/networking/Cargo.toml
@@ -11,6 +11,7 @@ discv5 = { workspace = true }
 enr = { workspace = true }
 env-config = { workspace = true }
 futures = { workspace = true }
+git-version = { workspace = true }
 hex = { workspace = true }
 k256 = { workspace = true }
 libp2p = { workspace = true }

--- a/lean_client/networking/src/compressor.rs
+++ b/lean_client/networking/src/compressor.rs
@@ -1,5 +1,9 @@
+use crate::gossipsub::topic::{GossipsubKind, GossipsubTopic};
 use libp2p::gossipsub::{DataTransform, Message, RawMessage, TopicHash};
+use metrics::METRICS;
+use sha2::{Digest, Sha256};
 use snap::raw::{Decoder, Encoder};
+use tracing::info;
 
 pub struct Compressor;
 
@@ -17,23 +21,71 @@ impl Default for Compressor {
 impl DataTransform for Compressor {
     fn inbound_transform(&self, raw_message: RawMessage) -> Result<Message, std::io::Error> {
         let mut decoder = Decoder::new();
-        let data = decoder.decompress_vec(&raw_message.data)?;
-
-        Ok(Message {
-            topic: raw_message.topic,
-            data,
-            sequence_number: raw_message.sequence_number,
-            source: raw_message.source,
-        })
+        match decoder.decompress_vec(&raw_message.data) {
+            Ok(data) => Ok(Message {
+                topic: raw_message.topic,
+                data,
+                sequence_number: raw_message.sequence_number,
+                source: raw_message.source,
+            }),
+            Err(e) => {
+                let kind = match GossipsubTopic::decode(&raw_message.topic) {
+                    Ok(t) => match t.kind {
+                        GossipsubKind::Block => "block",
+                        GossipsubKind::Aggregation => "aggregation",
+                        GossipsubKind::AttestationSubnet(_) => "attestation",
+                    },
+                    Err(_) => "unknown",
+                };
+                METRICS.get().map(|m| {
+                    m.lean_gossip_decompress_failures_total
+                        .with_label_values(&[kind])
+                        .inc();
+                });
+                Err(std::io::Error::other(e))
+            }
+        }
     }
 
     fn outbound_transform(
         &self,
-        _topic: &TopicHash,
+        topic: &TopicHash,
         data: Vec<u8>,
     ) -> Result<Vec<u8>, std::io::Error> {
         let mut encoder = Encoder::new();
         let raw_message = encoder.compress_vec(&data)?;
+
+        let kind = match GossipsubTopic::decode(topic) {
+            Ok(t) => match t.kind {
+                GossipsubKind::Block => "block",
+                GossipsubKind::Aggregation => "aggregation",
+                GossipsubKind::AttestationSubnet(_) => "attestation",
+            },
+            Err(_) => "unknown",
+        };
+
+        let sha256_ssz = hex::encode(Sha256::digest(&data));
+        let sha256_compressed = hex::encode(Sha256::digest(&raw_message));
+
+        let snappy_self_decode_ok: String = match kind {
+            "block" | "aggregation" => match Decoder::new().decompress_vec(&raw_message) {
+                Ok(round_trip) => (round_trip == data).to_string(),
+                Err(_) => "decode_error".to_string(),
+            },
+            _ => "skipped".to_string(),
+        };
+
+        info!(
+            target: "snappy_publish",
+            topic_kind = kind,
+            sha256_ssz = %&sha256_ssz[..16],
+            sha256_compressed = %&sha256_compressed[..16],
+            ssz_len = data.len(),
+            compressed_len = raw_message.len(),
+            snappy_self_decode_ok = %snappy_self_decode_ok,
+            git_sha = git_version::git_version!(args = ["--always", "--abbrev=8"], fallback = "unknown"),
+            "snappy publish",
+        );
 
         Ok(raw_message)
     }

--- a/lean_client/networking/src/network/service.rs
+++ b/lean_client/networking/src/network/service.rs
@@ -28,6 +28,7 @@ use metrics::{DisconnectReason, METRICS};
 use parking_lot::Mutex;
 use rand::seq::IndexedRandom;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use ssz::{H256, SszHash, SszWrite as _};
 use tokio::select;
 use tokio::sync::Notify;
@@ -669,7 +670,15 @@ where
                         }
                     }
                     Err(err) => {
-                        warn!(%err, topic = %message.topic, peer = %propagation_source, "gossip decode failed");
+                        let sha = hex::encode(Sha256::digest(&message.data));
+                        warn!(
+                            %err,
+                            topic = %message.topic,
+                            peer = %propagation_source,
+                            len = message.data.len(),
+                            sha256_inbound = %&sha[..16],
+                            "gossip decode failed"
+                        );
                     }
                 }
             }

--- a/lean_client/networking/src/network/service.rs
+++ b/lean_client/networking/src/network/service.rs
@@ -586,7 +586,11 @@ where
                 info!(peer = %peer_id, topic = %topic, "A peer unsubscribed from topic");
             }
 
-            Event::Message { message, .. } => {
+            Event::Message {
+                message,
+                propagation_source,
+                ..
+            } => {
                 let data_len = message.data.len();
                 match GossipsubMessage::decode(&message.topic, &message.data) {
                     Ok(GossipsubMessage::Block(signed_block)) => {
@@ -665,7 +669,7 @@ where
                         }
                     }
                     Err(err) => {
-                        warn!(%err, topic = %message.topic, "gossip decode failed");
+                        warn!(%err, topic = %message.topic, peer = %propagation_source, "gossip decode failed");
                     }
                 }
             }

--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -398,6 +398,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    xmss::setup_aggregation();
+
     tracing_subscriber::fmt()
         .with_ansi(std::io::stdout().is_terminal())
         .with_env_filter(

--- a/lean_client/xmss/Cargo.toml
+++ b/lean_client/xmss/Cargo.toml
@@ -7,6 +7,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bls = { workspace = true }
 derive_more = { workspace = true }
 eth_ssz = { workspace = true }
 ethereum-types = { workspace = true }

--- a/lean_client/xmss/src/aggregated_signature.rs
+++ b/lean_client/xmss/src/aggregated_signature.rs
@@ -35,7 +35,7 @@ impl SszSize for AggregatedSignature {
 impl<C> SszRead<C> for AggregatedSignature {
     fn from_ssz_unchecked(context: &C, bytes: &[u8]) -> Result<Self, ReadError> {
         let inner = ByteList::<AggregatedSignatureSizeLimit>::from_ssz_unchecked(context, bytes)?;
-        AggregatedXMSS::deserialize(inner.as_bytes()).ok_or(ReadError::Custom {
+        AggregatedXMSS::decompress(inner.as_bytes()).ok_or(ReadError::Custom {
             message: "invalid aggregated XMSS signature",
         })?;
         Ok(Self(inner))
@@ -56,7 +56,7 @@ impl SszHash for AggregatedSignature {
     }
 }
 
-fn setup_aggregation() {
+pub fn setup_aggregation() {
     static SETUP: Once = Once::new();
     SETUP.call_once(init_aggregation_bytecode);
 }
@@ -66,7 +66,7 @@ impl AggregatedSignature {
         let bytes = ByteList::try_from(bytes.to_vec())
             .context("signature too large - currently max 1MiB signatures allowed")?;
 
-        AggregatedXMSS::deserialize(bytes.as_bytes())
+        AggregatedXMSS::decompress(bytes.as_bytes())
             .ok_or_else(|| anyhow!("invalid aggregated signature"))?;
 
         Ok(Self(bytes))
@@ -154,7 +154,7 @@ impl AggregatedSignature {
             message.as_fixed_bytes(),
             slot,
             log_inv_rate,
-        );
+        )?;
 
         METRICS.get().map(|metrics| {
             metrics
@@ -162,7 +162,7 @@ impl AggregatedSignature {
                 .inc_by(sig_count as u64)
         });
 
-        let bytes = agg.serialize();
+        let bytes = agg.compress();
         Ok(Self(ByteList::try_from(bytes).context(
             "aggregated proof too large - exceeds 1MiB limit",
         )?))
@@ -207,7 +207,7 @@ impl AggregatedSignature {
     }
 
     fn as_lean(&self) -> Result<AggregatedXMSS> {
-        AggregatedXMSS::deserialize(self.0.as_bytes())
+        AggregatedXMSS::decompress(self.0.as_bytes())
             .ok_or_else(|| anyhow!("invalid aggregated XMSS signature"))
     }
 

--- a/lean_client/xmss/src/lib.rs
+++ b/lean_client/xmss/src/lib.rs
@@ -3,7 +3,7 @@ mod public_key;
 mod secret_key;
 mod signature;
 
-pub use aggregated_signature::AggregatedSignature;
+pub use aggregated_signature::{AggregatedSignature, setup_aggregation};
 pub use public_key::PublicKey;
 pub use secret_key::SecretKey;
 pub use signature::Signature;


### PR DESCRIPTION
Bumps leanMultisig to f66d4a974, ports leanSpec PRs #781  monotonic latest_justified guard and #802 skip finalization-advance for stale sources, pre-initializes XMSS aggregation on the main thread to dodge the macOS worker-stack overflow,and adds publish-side snappy fingerprint logging plus an inbound  lean_gossip_decompress_failures_total{topic_kind} counter for cross-client byte-mismatch debugging.                         