### PR TITLE
wrap State with Arc

### DIFF
--- a/lean_client/containers/src/block.rs
+++ b/lean_client/containers/src/block.rs
@@ -40,7 +40,13 @@ pub struct SignedBlock {
 }
 
 impl SignedBlock {
-    pub fn verify_signatures(&self, parent_state: State) -> Result<()> {
+    /// Verify all XMSS signatures in this signed block.
+    ///
+    /// Verifies each aggregated attestation proof against the participant
+    /// validator public keys from parent state.
+    ///
+    /// Returns `Ok(())` if all signatures are valid, or an error describing the failure.
+    pub fn verify_signatures(&self, parent_state: &State) -> Result<()> {
         let block = &self.block;
         let aggregated_attestations = &block.body.attestations;
 

--- a/lean_client/containers/tests/test_vectors/runner.rs
+++ b/lean_client/containers/tests/test_vectors/runner.rs
@@ -719,7 +719,7 @@ impl TestRunner {
             println!("  Expecting exception: {}", exception);
 
             // Verify signatures - we expect this to fail (return Err)
-            match signed_block.verify_signatures(anchor_state) {
+            match signed_block.verify_signatures(&anchor_state) {
                 Ok(()) => {
                     println!(
                         "    \x1b[31m✗ FAIL: Signatures verified successfully but should have failed!\x1b[0m\n"
@@ -734,7 +734,7 @@ impl TestRunner {
             }
         }
 
-        match signed_block.verify_signatures(anchor_state) {
+        match signed_block.verify_signatures(&anchor_state) {
             Ok(()) => {
                 println!("    ✓ All signatures verified successfully");
                 println!("\n\x1b[32m✓ PASS\x1b[0m\n");

--- a/lean_client/fork_choice/src/handlers.rs
+++ b/lean_client/fork_choice/src/handlers.rs
@@ -688,7 +688,7 @@ pub fn on_block(
 /// driving the function with synthetic signature placeholders (e.g. spec-test fixtures
 /// that ship unsigned blocks).
 pub fn verify_and_transition(
-    parent_state: State,
+    parent_state: Arc<State>,
     signed_block: SignedBlock,
     verify_signatures: bool,
 ) -> Result<State> {
@@ -699,7 +699,7 @@ pub fn verify_and_transition(
     });
 
     if verify_signatures {
-        signed_block.verify_signatures(parent_state.clone())?;
+        signed_block.verify_signatures(&parent_state)?;
     }
     parent_state.state_transition(&signed_block.block)
 }
@@ -714,6 +714,7 @@ pub fn apply_verified_block(
     block_root: H256,
 ) -> Result<()> {
     let block = signed_block.block.clone();
+    let new_state = Arc::new(new_state);
 
     tracing::debug!(
         block_slot = block.slot.0,
@@ -724,7 +725,7 @@ pub fn apply_verified_block(
     );
 
     store.blocks.insert(block_root, block.clone());
-    store.states.insert(block_root, new_state.clone());
+    store.states.insert(block_root, Arc::clone(&new_state));
 
     METRICS.get().map(|m| {
         m.grandine_store_blocks_size.set(store.blocks.len() as i64);

--- a/lean_client/fork_choice/src/store.rs
+++ b/lean_client/fork_choice/src/store.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use anyhow::{Result, anyhow, ensure};
 use containers::{
@@ -64,7 +65,9 @@ pub struct Store {
 
     pub blocks: HashMap<H256, Block>,
 
-    pub states: HashMap<H256, State>,
+    /// States are stored behind `Arc` so the many places that hand out a
+    /// snapshot of a state instead of deep-copying the whole state.
+    pub states: HashMap<H256, Arc<State>>,
 
     pub latest_known_attestations: HashMap<u64, AttestationData>,
 
@@ -266,7 +269,7 @@ pub fn get_forkchoice_store(
         },
         states: {
             let mut m = HashMap::new();
-            m.insert(block_root, anchor_state);
+            m.insert(block_root, Arc::new(anchor_state));
             m
         },
         latest_known_attestations: HashMap::new(),
@@ -369,7 +372,7 @@ pub fn get_fork_choice_head(
     }
 }
 
-pub fn get_latest_justified(states: &HashMap<H256, State>) -> Option<&Checkpoint> {
+pub fn get_latest_justified(states: &HashMap<H256, Arc<State>>) -> Option<&Checkpoint> {
     states
         .values()
         .map(|state| &state.latest_justified)
@@ -616,7 +619,7 @@ pub struct BlockProductionInputs {
     pub slot: Slot,
     pub validator_index: u64,
     pub head_root: H256,
-    pub head_state: State,
+    pub head_state: Arc<State>,
     pub known_block_roots: HashSet<H256>,
     /// Joined view of `latest_known_aggregated_payloads` keyed by `data_root`,
     /// with the `AttestationData` carried in the value. Entries whose

--- a/lean_client/http_api/src/test_driver.rs
+++ b/lean_client/http_api/src/test_driver.rs
@@ -309,7 +309,7 @@ async fn run_verify_signatures(
         }
     };
 
-    Json(match signed_block.verify_signatures(anchor_state) {
+    Json(match signed_block.verify_signatures(&anchor_state) {
         Ok(()) => VerifySignaturesResponse {
             succeeded: true,
             error: None,

--- a/lean_client/src/main.rs
+++ b/lean_client/src/main.rs
@@ -952,7 +952,7 @@ async fn main() -> Result<()> {
                                     // proposer_signature is NOT covered by the hash — verify it
                                     // explicitly so a peer serving a validly-hashed but unsigned
                                     // block cannot become our anchor.
-                                    match signed_block.verify_signatures(anchor_state.clone()) {
+                                    match signed_block.verify_signatures(&anchor_state) {
                                         Ok(()) => {
                                             info!(
                                                 slot = signed_block.block.slot.0,


### PR DESCRIPTION
Reduce unnecessary `State` cloning in fork-choice by storing retained states behind `Arc<State>` and passing shared state snapshots by reference where possible.