### PR TITLE
Wire up hive tests on CI

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -1,0 +1,43 @@
+name: Hive
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hive:
+    name: Run hive tests
+    runs-on: ubuntu-latest
+    # hive itself imposes no timeout; cap the job so a hang can't run forever.
+    timeout-minutes: 180
+    env:
+      # `docker-local` -> `cross` bind-mounts this into the build container.
+      LEAN_REPO_ROOT: ${{ github.workspace }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Needed to build the hive binary (`go build .`).
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+
+      # Needed by `docker-local` to cross-build the x86_64 client binary.
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 7b24b6e9f6834a3ac31d3dad1e2ff24c1b66f7cf
+
+      # hive launches client containers; restart docker to settle iptables
+      # rules on the runner (same workaround the zeam hive workflow uses).
+      - name: Restart docker
+        run: sudo systemctl restart docker
+
+      - name: Run hive tests
+        run: make test-hive

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ lean_client/target/*
 lean_client/tests/mainnet
 lean_client/bin
 lean_client/spec/
+lean_client/hive/
 target/*
 *.local*
 

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,7 @@ docker-local:
 .PHONY: release
 release:
 	$(MAKE) -C lean_client release
+
+.PHONY: test-hive
+test-hive:
+	$(MAKE) -C lean_client test-hive

--- a/README.md
+++ b/README.md
@@ -71,3 +71,27 @@ leanEthereum Consensus Client written in Rust using Grandine's libraries.
    ```
    
 After a minute all the nodes should be synced up and see each other
+
+## Running Hive tests
+
+Runs the [Hive](https://github.com/ethereum/hive) lean simulator against our
+`grandine_lean` client. From the repo root:
+
+```bash
+make test-hive
+```
+
+Requires a **Go toolchain**, **Docker** (running, usable without `sudo`), and
+**Rust + [`cross`](https://github.com/cross-rs/cross)**.
+
+Pin a hive version (defaults to latest `master`):
+
+```bash
+make test-hive HIVE_VERSION=<full-commit-hash>
+```
+
+Remove the hive clone and other build artifacts:
+
+```bash
+make clean
+```

--- a/lean_client/Makefile
+++ b/lean_client/Makefile
@@ -148,7 +148,7 @@ test-hive: hive/hive docker-local
 	fi; \
 	if ! command -v jq >/dev/null 2>&1; then \
 		echo "jq not found; skipping summary. Raw results under $$logs"; \
-		exit 0; \
+		exit $$hive_status; \
 	fi; \
 	summary=$$( \
 		echo "==================== Hive test summary ===================="; \
@@ -174,7 +174,8 @@ test-hive: hive/hive docker-local
 	printf '%s\n' "$$summary"; \
 	if [ -n "$$GITHUB_STEP_SUMMARY" ]; then \
 		{ echo '```'; printf '%s\n' "$$summary"; echo '```'; } >> "$$GITHUB_STEP_SUMMARY"; \
-	fi
+	fi; \
+	exit $$hive_status
 
 hive/hive: hive/.hive-ref-$(HIVE_VERSION)
 	@echo "==> Building hive binary (go build)..."

--- a/lean_client/Makefile
+++ b/lean_client/Makefile
@@ -20,6 +20,13 @@ CURRENT_DEVNET := devnet-5
 # Repo root that cross bind-mounts into its build container (see
 # `lean_client/Cross.toml`). Auto-derived locally; CI overrides via env.
 LEAN_REPO_ROOT ?= $(shell git rev-parse --show-toplevel)
+# ethereum/hive ref to build. Defaults to latest master, resolved at clone time.
+# Override with `make test-hive HIVE_VERSION=<commit>` to pin a specific commit.
+HIVE_VERSION ?= master
+# Devnet variant of the grandine lean hive client to test. Selects the client
+# definition (`simulators/lean/clients/<HIVE_DEVNET>.yaml`) and image
+# (`grandine_lean_<HIVE_DEVNET>`). Note: hive uses `devnet5` (no hyphen).
+HIVE_DEVNET ?= devnet5
 
 # Temporary variable, which constructs `--tag` arguments, to be passed into 
 #   docker build command. It is used as intermediatery step, not as config 
@@ -72,18 +79,23 @@ build:
 clean:
 	cargo clean
 	rm -rf ./bin
+	rm -rf ./hive
+
+CLIENT_SOURCES := $(shell find . \
+	\( -path './target' -o -path './hive' -o -path './spec' -o -path './bin' \) -prune \
+	-o \( -name '*.rs' -o -name 'Cargo.toml' \) -print) Cargo.lock
 
 .PHONY: x86_64-unknown-linux-gnu
 x86_64-unknown-linux-gnu: ./target/x86_64-unknown-linux-gnu/release/lean_client
 
-./target/x86_64-unknown-linux-gnu/release/lean_client:
+./target/x86_64-unknown-linux-gnu/release/lean_client: $(CLIENT_SOURCES)
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C target-cpu=x86-64-v3" \
 	LEAN_REPO_ROOT=$(LEAN_REPO_ROOT) cross build --bin lean_client --target x86_64-unknown-linux-gnu --profile release
 
 .PHONY: aarch64-unknown-linux-gnu
 aarch64-unknown-linux-gnu: ./target/aarch64-unknown-linux-gnu/release/lean_client
 
-./target/aarch64-unknown-linux-gnu/release/lean_client:
+./target/aarch64-unknown-linux-gnu/release/lean_client: $(CLIENT_SOURCES)
 	LEAN_REPO_ROOT=$(LEAN_REPO_ROOT) cross build --bin lean_client --target aarch64-unknown-linux-gnu --profile release
 
 .PHONY: release
@@ -116,6 +128,69 @@ docker-local: ./target/x86_64-unknown-linux-gnu/release/lean_client
 		--build-arg GIT_BRANCH=$(GIT_BRANCH) \
 		$(DOCKER_TAGS) \
 		.
+
+### Hive
+.PHONY: test-hive
+test-hive: hive/hive docker-local
+	@cd hive && \
+	./hive --sim lean \
+		--client-file simulators/lean/clients/$(HIVE_DEVNET).yaml \
+		--client grandine_lean_$(HIVE_DEVNET) \
+		--docker.output \
+		--docker.nocache="hive/clients/grandine_lean_$(HIVE_DEVNET)" \
+		--results-root ./workspace/logs; \
+	hive_status=$$?; \
+	logs=./workspace/logs; \
+	suites=$$(ls $$logs/*.json 2>/dev/null | grep -v '/hive\.json$$' || true); \
+	if [ -z "$$suites" ]; then \
+		echo "ERROR: hive produced no suite results - treating as an infrastructure/script failure."; \
+		exit $$hive_status; \
+	fi; \
+	if ! command -v jq >/dev/null 2>&1; then \
+		echo "jq not found; skipping summary. Raw results under $$logs"; \
+		exit 0; \
+	fi; \
+	summary=$$( \
+		echo "==================== Hive test summary ===================="; \
+		total=0; failed_total=0; \
+		for f in $$suites; do \
+			name=$$(jq -r '.name' "$$f"); \
+			n=$$(jq '.testCases | length' "$$f"); \
+			nf=$$(jq '[.testCases[] | select(.summaryResult.pass | not)] | length' "$$f"); \
+			total=$$((total + n)); failed_total=$$((failed_total + nf)); \
+			if [ "$$nf" -eq 0 ]; then \
+				printf '%s: %d/%d passed\n' "$$name" "$$n" "$$n"; \
+			else \
+				printf '%s: %d/%d passed (%d failed)\n' "$$name" "$$((n - nf))" "$$n" "$$nf"; \
+				jq -r '.testCases[] | select(.summaryResult.pass | not) | "  FAIL: \(.name)"' "$$f"; \
+			fi; \
+		done; \
+		echo "-----------------------------------------------------------"; \
+		printf 'Total: %d/%d passed, %d failed\n' "$$((total - failed_total))" "$$total" "$$failed_total"; \
+		echo "Full failure details: lean_client/hive/workspace/logs/details/"; \
+		echo "===========================================================" \
+	); \
+	echo; \
+	printf '%s\n' "$$summary"; \
+	if [ -n "$$GITHUB_STEP_SUMMARY" ]; then \
+		{ echo '```'; printf '%s\n' "$$summary"; echo '```'; } >> "$$GITHUB_STEP_SUMMARY"; \
+	fi
+
+hive/hive: hive/.hive-ref-$(HIVE_VERSION)
+	@echo "==> Building hive binary (go build)..."
+	@cd hive && go build .
+	@echo "==> Built hive binary at hive/hive ($$(cd hive && git rev-parse --short HEAD))"
+
+hive/.hive-ref-$(HIVE_VERSION):
+	@echo "==> Fetching ethereum/hive at ref '$(HIVE_VERSION)'..."
+	@rm -rf hive
+	@mkdir -p hive
+	@cd hive && git init -q && \
+		git remote add origin https://github.com/ethereum/hive.git && \
+		git fetch --depth 1 -q origin $(HIVE_VERSION) && \
+		git switch -q --detach FETCH_HEAD
+	@echo "==> Checked out hive at $$(cd hive && git rev-parse --short HEAD)"
+	@touch $@
 
 ### Shadow-simulator support
 # `rust/patch/quinn-udp` is a vendored fallback-only build of quinn-udp so QUIC


### PR DESCRIPTION
fixes #117

## Checklist

Self-check your solution before submitting:

  * [x] Verify `make test-hive` works, on a clean repo checkout, without additional setup (apart from system installation, like `go` toolchain);
  * [x] Verify that running `make test-hive` second time doesn't rebuild hive itself;
  * [x] Verify that running `make test-hive HIVE_VERSION=<some_other_commit_hash>` rebuilds hive properly and re-runs tests;
  * [x] Verify that modifying code in grandine (you can just insert some print in ./lean_client/src/main.rs`) rebuilds docker image and re-runs hive tests;
  * [x] Verify that your script runs all hive tests, available for grandine lean client;
  * [x] Verify your CI works (not necessarily passes, just runs tests) on your own fork;
  * [x] Verify that `make clean` cleans up `hive` directory;
  * [x] Don't forget to update README.md - include section what needs to be installed (probably only go toolchain) for running hive tests, and how to run them.
  
## Additions beyond the checklist: 

- Per-suite summary  - each suite's pass/total count + names of failed test cases, printed to the job logs and rendered as a GitHub Step Summary panel.
- Infra-vs-test failure semantics - a completed run with failing tests is reported but does not fail the job; only a genuine build/run failure (no results produced) fails it. A red check means the pipeline broke, not that a spec test failed.
- ~~Label-gated CI — runs only on PRs with the run-hive label (plus manual workflow_dispatch), not on every push, since the full suite is slow.~~

Example run (summary panel on the Summary page): https://github.com/SamAg19/lean/actions/runs/30262177584?pr=1; the committed workflow runs the full suite. Example PR where i tested out everything: https://github.com/SamAg19/lean/pull/1